### PR TITLE
github action integrate codecov

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,10 +1,6 @@
-# 1.setup go env
-# 2.make checkfmt
-# 3.make test
+name: Test and coverage
 
-name: code-check-test
-
-on: [pull_request]
+on: [push, pull_request]
 
 # This ensures that previous jobs for the PR are canceled when the PR is updated.
 concurrency:
@@ -12,8 +8,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fmtcheck:
-    name: Code fmtcheck
+  test:
+    name: Go Test
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
@@ -27,10 +23,9 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Check pr is properly formatted
-        run: diff -u <(echo -n) <(gofmt -d ./pkg ./cmd ./tools ./test)
-
-      - name: Checkfmt
+      - name: Run coverage
         shell: bash
-        # maybe timeout, use --timeout optional
-        run: make checkfmt
+        run: |
+          make test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,9 @@ build-e2e:
 openapi:
 	go run ./tools/doc-gen/main.go
 
-.PHONY:test coverage-ui
+.PHONY:test
 test:
-	go test ./pkg/... -coverprofile=dist/coverage.out
-
-coverage-ui:test
-	go tool cover -html=dist/coverage.out -o dist/coverage.html
+	go test -race ./pkg/... -coverprofile=coverage.out -covermode=atomic
 
 .PHONY: format-deps checkfmt fmt goimports vet lint
 format-deps:


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind flake

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #11 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```