### PR TITLE
fix: Recovery fs storages type nil pointer dereference

### DIFF
--- a/pkg/apis/core/v1/utils.go
+++ b/pkg/apis/core/v1/utils.go
@@ -229,18 +229,20 @@ func getRecoveryStep(c *v1.Cluster, bp *v1.BackupPoint, b *v1.Backup, restoreDir
 	}
 
 	r := k8s.Recovery{
-		BackupPointRootDir: bp.FsConfig.BackupRootDir,
-		StoreType:          bp.StorageType,
-		RestoreDir:         restoreDir,
-		BackupFileName:     b.FileName,
-		NodeNameList:       nodeNames,
-		NodeIPList:         nodeIPs,
-		BackupFileSize:     b.Status.BackupFileSize,
-		BackupFileMD5:      b.Status.BackupFileMD5,
-		FileDir:            f,
+		StoreType:      bp.StorageType,
+		RestoreDir:     restoreDir,
+		BackupFileName: b.FileName,
+		NodeNameList:   nodeNames,
+		NodeIPList:     nodeIPs,
+		BackupFileSize: b.Status.BackupFileSize,
+		BackupFileMD5:  b.Status.BackupFileMD5,
+		FileDir:        f,
 	}
 
-	if bp.StorageType == bs.S3Storage {
+	switch bp.StorageType {
+	case bs.FSStorage:
+		r.BackupPointRootDir = bp.FsConfig.BackupRootDir
+	case bs.S3Storage:
 		r.AccessKeyID = bp.S3Config.AccessKeyID
 		r.AccessKeySecret = bp.S3Config.AccessKeySecret
 		r.Bucket = bp.S3Config.Bucket


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <zhu.zhenfan@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
### What this PR does / why we need it:
fix: Recovery fs storages type nil pointer dereference
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```