### PR TITLE
feat: add the K8S mirror proxy setting option

### DIFF
--- a/cmd/kubeclipper-agent/app/options/options.go
+++ b/cmd/kubeclipper-agent/app/options/options.go
@@ -43,6 +43,7 @@ func (s *AgentOptions) Validate() []error {
 	errors = append(errors, s.GenericServerRunOptions.Validate()...)
 	errors = append(errors, s.LogOptions.Validate()...)
 	errors = append(errors, s.OpLogOptions.Validate()...)
+	errors = append(errors, s.ImageProxyOptions.Validate()...)
 	return errors
 }
 
@@ -52,6 +53,8 @@ func (s *AgentOptions) Flags() (fss cliflag.NamedFlagSets) {
 	s.LogOptions.AddFlags(fss.FlagSet("log"))
 	s.MQOptions.AddFlags(fss.FlagSet("mq"))
 	s.OpLogOptions.AddFlags(fss.FlagSet("oplog"))
+	s.ImageProxyOptions.AddFlags(fss.FlagSet("imageProxy"))
+
 	return fss
 }
 

--- a/kubeclipper-agent.yaml
+++ b/kubeclipper-agent.yaml
@@ -49,3 +49,5 @@ backupStore:
 #    accessKeySecret: secret
 #    ssl: true
 #    region: default
+imageProxy:
+  kcImageRepoMirror: ""

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -40,6 +40,7 @@ func (s *Server) PrepareRun(stopCh <-chan struct{}) error {
 		task.WithNodeStatusUpdateFrequency(s.Config.NodeStatusUpdateFrequency),
 		task.WithLeaseDurationSeconds(240),
 		task.WithOplog(opLog),
+		task.WithRepoMirror(s.Config.ImageProxyOptions.KcImageRepoMirror),
 	)
 	return s.taskService.PrepareRun(stopCh)
 }

--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kubeclipper/kubeclipper/pkg/simple/imageproxy"
+
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 
@@ -51,6 +53,7 @@ type Config struct {
 	LogOptions                *logger.Options     `json:"log,omitempty" yaml:"log,omitempty" mapstructure:"log"`
 	MQOptions                 *natsio.NatsOptions `json:"mq,omitempty" yaml:"mq,omitempty"  mapstructure:"mq"`
 	OpLogOptions              *oplog.Options      `json:"oplog,omitempty" yaml:"oplog,omitempty" mapstructure:"oplog"`
+	ImageProxyOptions         *imageproxy.Options `json:"imageProxy,omitempty" yaml:"imageProxy,omitempty" mapstructure:"imageProxy"`
 }
 
 func New() *Config {
@@ -61,6 +64,7 @@ func New() *Config {
 		MQOptions:                 natsio.NewOptions(),
 		DownloaderOptions:         downloader.NewOptions(),
 		OpLogOptions:              oplog.NewOptions(),
+		ImageProxyOptions:         imageproxy.NewOptions(),
 	}
 }
 

--- a/pkg/cli/config/template.go
+++ b/pkg/cli/config/template.go
@@ -284,6 +284,8 @@ backupStore:
   type: fs
   provider:
     rootdir: /opt/kc/backups
+imageProxy:
+  kcImageRepoMirror: {{.KcImageRepoMirror}}
 `
 
 const DockerDaemonTmpl = `

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -648,7 +648,6 @@ func (d *DeployOptions) getKcServerConfigTemplateContent(ip string) string {
 		data["MQClientCertPath"] = d.deployConfig.MQ.ClientCert
 		data["MQClientKeyPath"] = d.deployConfig.MQ.ClientKey
 	}
-
 	var buffer bytes.Buffer
 	if err := tmpl.Execute(&buffer, data); err != nil {
 		logger.Fatalf("template execute failed: %s", err.Error())
@@ -688,6 +687,7 @@ func (d *DeployOptions) getKcAgentConfigTemplateContent(region string) string {
 	}
 	data["OpLogDir"] = d.deployConfig.OpLog.Dir
 	data["OpLogThreshold"] = d.deployConfig.OpLog.Threshold
+	data["KcImageRepoMirror"] = d.deployConfig.ImageProxy.KcImageRepoMirror
 	var buffer bytes.Buffer
 	if err = tmpl.Execute(&buffer, data); err != nil {
 		logger.Fatalf("template execute failed: %s", err.Error())

--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -331,6 +331,7 @@ func (c *JoinOptions) getKcAgentConfigTemplateContent(region string) string {
 	}
 	data["OpLogDir"] = c.deployConfig.OpLog.Dir
 	data["OpLogThreshold"] = c.deployConfig.OpLog.Threshold
+	data["KcImageRepoMirror"] = c.deployConfig.ImageProxy.KcImageRepoMirror
 	var buffer bytes.Buffer
 	if err = tmpl.Execute(&buffer, data); err != nil {
 		logger.Fatalf("template execute failed: %s", err.Error())

--- a/pkg/component/ctx.go
+++ b/pkg/component/ctx.go
@@ -29,6 +29,7 @@ type (
 	stepKey      struct{}
 	oplogKey     struct{}
 	retryKey     struct{}
+	repoMirror   struct{}
 )
 
 type ExtraMetadata struct {
@@ -191,4 +192,15 @@ func GetRetry(ctx context.Context) bool {
 		return v.(bool)
 	}
 	return false
+}
+
+func WithRepoMirror(ctx context.Context, mirror string) context.Context {
+	return context.WithValue(ctx, repoMirror{}, mirror)
+}
+
+func GetRepoMirror(ctx context.Context) string {
+	if v := ctx.Value(repoMirror{}); v != nil {
+		return v.(string)
+	}
+	return ""
 }

--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -210,6 +210,11 @@ func (runnable *ContainerdRunnable) matchPauseVersion(kubeVersion string) string
 }
 
 func (runnable *ContainerdRunnable) setupContainerdConfig(ctx context.Context, dryRun bool) error {
+	// local registry not filled and is in online mode, the default repo mirror proxy will be used
+	if !runnable.Offline && runnable.LocalRegistry == "" {
+		runnable.LocalRegistry = component.GetRepoMirror(ctx)
+		logger.Info("render containerd config, the default repo mirror proxy will be used", zap.String("local_registry", runnable.LocalRegistry))
+	}
 	cf := filepath.Join(containerdDefaultConfigDir, "config.toml")
 	if err := os.MkdirAll(containerdDefaultConfigDir, 0755); err != nil {
 		return err

--- a/pkg/scheme/core/v1/k8s/kubeadm.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm.go
@@ -109,6 +109,7 @@ type KubeadmConfig struct {
 	ControlPlaneEndpoint string        `json:"controlPlaneEndpoint"`
 	CertSANs             []string      `json:"certSANs"`
 	LocalRegistry        string        `json:"localRegistry"`
+	Offline              bool          `json:"offline"`
 }
 
 type ControlPlane struct {
@@ -257,6 +258,11 @@ func (stepper KubeadmConfig) Render(ctx context.Context, opts component.Options)
 
 	if stepper.Kubelet.RootDir == "" {
 		stepper.Kubelet.RootDir = KubeletDefaultDataDir
+	}
+	// local registry not filled and is in online mode, the default repo mirror proxy will be used
+	if !stepper.Offline && stepper.LocalRegistry == "" {
+		stepper.LocalRegistry = component.GetRepoMirror(ctx)
+		logger.Info("render kubernetes config, the default repo mirror proxy will be used", zap.String("local_registry", stepper.LocalRegistry))
 	}
 
 	if err := os.MkdirAll(ManifestDir, 0755); err != nil {

--- a/pkg/scheme/core/v1/k8s/kubeadm_step.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_step.go
@@ -359,6 +359,7 @@ func (stepper *KubeadmConfig) InitStepper(c *v1.Cluster, metadata *component.Ext
 	stepper.ControlPlaneEndpoint = cpEndpoint
 	stepper.CertSANs = c.CertSANs
 	stepper.LocalRegistry = c.LocalRegistry
+	stepper.Offline = metadata.Offline
 
 	return stepper
 }

--- a/pkg/scheme/core/v1/k8s/template.go
+++ b/pkg/scheme/core/v1/k8s/template.go
@@ -616,7 +616,7 @@ spec:
      priorityClassName: system-node-critical
      initContainers:
        - name: upgrade-ipam
-         image: {{with .CNI.LocalRegistry}}{{.}}/{{end}}calico/cni:{{.CNI.Calico.Version}}
+         image: {{with .CNI.LocalRegistry}}{{.}}/{{end}}calico/cni:{{.CNI.Version}}
          command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
          env:
            - name: KUBERNETES_NODE_NAME
@@ -636,7 +636,7 @@ spec:
          securityContext:
            privileged: true
        - name: install-cni
-         image: {{with .CNI.LocalRegistry}}{{.}}/{{end}}calico/cni:{{.CNI.Calico.Version}}
+         image: {{with .CNI.LocalRegistry}}{{.}}/{{end}}calico/cni:{{.CNI.Version}}
          command: ["/install-cni.sh"]
          env:
            - name: CNI_CONF_NAME
@@ -665,7 +665,7 @@ spec:
          securityContext:
            privileged: true
        - name: flexvol-driver
-         image: {{with .CNI.LocalRegistry }}{{.}}/{{end}}calico/pod2daemon-flexvol:{{.CNI.Calico.Version}}
+         image: {{with .CNI.LocalRegistry }}{{.}}/{{end}}calico/pod2daemon-flexvol:{{.CNI.Version}}
          volumeMounts:
          - name: flexvol-driver-host
            mountPath: /host/driver
@@ -673,7 +673,7 @@ spec:
            privileged: true
      containers:
        - name: calico-node
-         image: {{with .CNI.LocalRegistry}}{{.}}/{{end}}calico/node:{{.CNI.Calico.Version}}
+         image: {{with .CNI.LocalRegistry}}{{.}}/{{end}}calico/node:{{.CNI.Version}}
          env:
            - name: DATASTORE_TYPE
              value: "kubernetes"
@@ -700,23 +700,23 @@ spec:
            - name: CALICO_IPV6POOL_CIDR
              value: "{{.PodIPv6CIDR}}"
            - name: IP6_AUTODETECTION_METHOD
-             value: "{{.Calico.IPv6AutoDetection}}"
+             value: "{{.CNI.Calico.IPv6AutoDetection}}"
            {{end}}
-           {{if eq .Calico.Mode "BGP"}}
+           {{if eq .CNI.Calico.Mode "BGP"}}
            - name: CALICO_IPV4POOL_IPIP
              value: "Never"
-           {{else if eq .Calico.Mode "Overlay-IPIP-All"}}
+           {{else if eq .CNI.Calico.Mode "Overlay-IPIP-All"}}
            - name: CALICO_IPV4POOL_IPIP
              value: "Always"
-           {{else if eq .Calico.Mode "Overlay-IPIP-Cross-Subnet"}}
+           {{else if eq .CNI.Calico.Mode "Overlay-IPIP-Cross-Subnet"}}
            - name: CALICO_IPV4POOL_IPIP
              value: "CrossSubnet"
-           {{else if eq .Calico.Mode "Overlay-Vxlan-All"}}
+           {{else if eq .CNI.Calico.Mode "Overlay-Vxlan-All"}}
            - name: CALICO_IPV4POOL_IPIP
              value: "Never"
            - name: CALICO_IPV4POOL_VXLAN
              value: "Always"
-           {{else if eq .Calico.Mode "Overlay-Vxlan-Cross-Subnet"}}
+           {{else if eq .CNI.Calico.Mode "Overlay-Vxlan-Cross-Subnet"}}
            - name: CALICO_IPV4POOL_IPIP
              value: "Never"
            - name: CALICO_IPV4POOL_VXLAN
@@ -852,7 +852,7 @@ spec:
      priorityClassName: system-cluster-critical
      containers:
        - name: calico-kube-controllers
-         image: {{with .LocalRegistry}}{{.}}/{{end}}calico/kube-controllers:{{.Calico.Version}}
+         image: {{with .CNI.LocalRegistry}}{{.}}/{{end}}calico/kube-controllers:{{.CNI.Version}}
          env:
            - name: ENABLED_CONTROLLERS
              value: node
@@ -4982,7 +4982,7 @@ spec:
               value: "Never"
             - name: CALICO_IPV4POOL_VXLAN
               value: "Always"
-            {{else if eq .Calico.Mode "Overlay-Vxlan-Cross-Subnet"}}
+            {{else if eq .CNI.Calico.Mode "Overlay-Vxlan-Cross-Subnet"}}
             - name: CALICO_IPV4POOL_IPIP
               value: "Never"
             - name: CALICO_IPV4POOL_VXLAN

--- a/pkg/service/task/handler.go
+++ b/pkg/service/task/handler.go
@@ -43,6 +43,7 @@ func (s *Service) runTaskStep(ctx context.Context, payload *service.MsgPayload, 
 	ctx = component.WithOperationID(ctx, payload.OperationIdentity) // put operation ID into context
 	ctx = component.WithStepID(ctx, stepKey)                        // put step ID into context
 	ctx = component.WithOplog(ctx, s.oplog)                         // put operation log object into context
+	ctx = component.WithRepoMirror(ctx, s.repoMirror)
 
 	var entry string
 	// truncate step log file

--- a/pkg/service/task/service.go
+++ b/pkg/service/task/service.go
@@ -98,6 +98,7 @@ type Service struct {
 	latestLease *coordinationv1.Lease
 	oplog       component.OperationLogFile
 	backupStore bs.BackupStore
+	repoMirror  string
 }
 
 type ServiceOption func(*Service)
@@ -117,6 +118,12 @@ func WithOplog(ol component.OperationLogFile) ServiceOption {
 func WithBackupStore(backupStore bs.BackupStore) ServiceOption {
 	return func(s *Service) {
 		s.backupStore = backupStore
+	}
+}
+
+func WithRepoMirror(mirror string) ServiceOption {
+	return func(s *Service) {
+		s.repoMirror = mirror
 	}
 }
 

--- a/pkg/simple/imageproxy/options.go
+++ b/pkg/simple/imageproxy/options.go
@@ -1,0 +1,35 @@
+package imageproxy
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/spf13/pflag"
+)
+
+type Options struct {
+	KcImageRepoMirror string `json:"kcImageRepoMirror" yaml:"kcImageRepoMirror"`
+}
+
+func NewOptions() *Options {
+	return &Options{
+		KcImageRepoMirror: "",
+	}
+}
+
+func (s *Options) Validate() []error {
+	var errs []error
+	uri, err := url.Parse(s.KcImageRepoMirror)
+	if err != nil {
+		errs = append(errs, err)
+		return errs
+	}
+	if uri.Scheme != "" {
+		errs = append(errs, fmt.Errorf("kc image repo mirror is not support incoming protcol: %s", uri.Scheme))
+	}
+	return errs
+}
+
+func (s *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&s.KcImageRepoMirror, "kc-image-repo-mirror", s.KcImageRepoMirror, "K8s image repository mirror")
+}


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #47 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
1. When you run the KCCTL quick installation script, you can set the KC_REGION environment variable in advance. The script dynamically generates the repo mirror env file based on the value of the variable.
2. Currently supported KC_REGION=cn, then the script automatically sets the third-party repo mirror proxy.
3. Users can set KC_IMAGE_REPO_MIRROR variable to customize the third-party repo mirror proxy.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```