### PR TITLE
make backuppoint and cornbackup impl watch func

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -2527,6 +2527,10 @@ func (h *handler) DescribeBackupPoint(request *restful.Request, response *restfu
 
 func (h *handler) ListBackupPoints(request *restful.Request, response *restful.Response) {
 	q := query.ParseQueryParameter(request)
+	if q.Watch {
+		h.watchBackupPoints(request, response, q)
+		return
+	}
 	if clientrest.IsInformerRawQuery(request.Request) {
 		result, err := h.clusterOperator.ListBackupPoints(request.Request.Context(), q)
 		if err != nil {
@@ -2542,6 +2546,23 @@ func (h *handler) ListBackupPoints(request *restful.Request, response *restful.R
 		}
 		_ = response.WriteHeaderAndEntity(http.StatusOK, result)
 	}
+}
+
+func (h *handler) watchBackupPoints(req *restful.Request, resp *restful.Response, q *query.Query) {
+	timeout := time.Duration(0)
+	if q.TimeoutSeconds != nil {
+		timeout = time.Duration(*q.TimeoutSeconds) * time.Second
+	}
+	if timeout == 0 {
+		timeout = time.Duration(float64(query.MinTimeoutSeconds) * (rand.Float64() + 1.0))
+	}
+
+	watcher, err := h.clusterOperator.WatchBackupPoints(req.Request.Context(), q)
+	if err != nil {
+		restplus.HandleInternalError(resp, req, err)
+		return
+	}
+	restplus.ServeWatch(watcher, v1.SchemeGroupVersion.WithKind("BackupPoint"), req, resp, timeout)
 }
 
 func (h *handler) CreateBackupPoint(request *restful.Request, response *restful.Response) {
@@ -2641,6 +2662,10 @@ func (h *handler) DescribeCronBackup(request *restful.Request, response *restful
 
 func (h *handler) ListCronBackups(request *restful.Request, response *restful.Response) {
 	q := query.ParseQueryParameter(request)
+	if q.Watch {
+		h.watchCronBackups(request, response, q)
+		return
+	}
 	if clientrest.IsInformerRawQuery(request.Request) {
 		result, err := h.clusterOperator.ListCronBackups(request.Request.Context(), q)
 		if err != nil {
@@ -2656,6 +2681,23 @@ func (h *handler) ListCronBackups(request *restful.Request, response *restful.Re
 		}
 		_ = response.WriteHeaderAndEntity(http.StatusOK, result)
 	}
+}
+
+func (h *handler) watchCronBackups(req *restful.Request, resp *restful.Response, q *query.Query) {
+	timeout := time.Duration(0)
+	if q.TimeoutSeconds != nil {
+		timeout = time.Duration(*q.TimeoutSeconds) * time.Second
+	}
+	if timeout == 0 {
+		timeout = time.Duration(float64(query.MinTimeoutSeconds) * (rand.Float64() + 1.0))
+	}
+
+	watcher, err := h.clusterOperator.WatchCronBackups(req.Request.Context(), q)
+	if err != nil {
+		restplus.HandleInternalError(resp, req, err)
+		return
+	}
+	restplus.ServeWatch(watcher, v1.SchemeGroupVersion.WithKind("CronBackup"), req, resp, timeout)
 }
 
 func (h *handler) CreateCronBackup(request *restful.Request, response *restful.Response) {

--- a/pkg/controller/cluster_status.go
+++ b/pkg/controller/cluster_status.go
@@ -22,9 +22,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kubeclipper/kubeclipper/pkg/service"
 	"strings"
 	"time"
+
+	"github.com/kubeclipper/kubeclipper/pkg/service"
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/models/cluster/cluster.go
+++ b/pkg/models/cluster/cluster.go
@@ -368,6 +368,14 @@ func (c *clusterOperator) ListCronBackups(ctx context.Context, query *query.Quer
 	return list.(*v1.CronBackupList), nil
 }
 
+func (c *clusterOperator) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	return models.Watch(ctx, c.backupPointStorage, query)
+}
+
+func (c *clusterOperator) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	return models.Watch(ctx, c.cronBackupStorage, query)
+}
+
 func (c *clusterOperator) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	return models.ListExV2(ctx, c.cronBackupStorage, query, c.cronBackupFuzzyFilter, nil, nil)
 }

--- a/pkg/models/cluster/interface.go
+++ b/pkg/models/cluster/interface.go
@@ -173,6 +173,7 @@ type BackupPointReaderEx interface {
 type BackupPointReader interface {
 	ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error)
 	GetBackupPoint(ctx context.Context, name string, resourceVersion string) (*v1.BackupPoint, error)
+	WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error)
 	BackupPointReaderEx
 }
 
@@ -190,6 +191,7 @@ type CronBackupReaderEx interface {
 type CronBackupReader interface {
 	ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error)
 	GetCronBackup(ctx context.Context, name string, resourceVersion string) (*v1.CronBackup, error)
+	WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error)
 	CronBackupReaderEx
 }
 

--- a/pkg/models/cluster/mock/mock_cluster.go
+++ b/pkg/models/cluster/mock/mock_cluster.go
@@ -6,309 +6,38 @@ package mock_cluster
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/kubeclipper/kubeclipper/pkg/models"
 	query "github.com/kubeclipper/kubeclipper/pkg/query"
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
+	reflect "reflect"
 )
 
-// MockOperatorReader is a mock of OperatorReader interface.
+// MockOperatorReader is a mock of OperatorReader interface
 type MockOperatorReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockOperatorReaderMockRecorder
 }
 
-// MockOperatorReaderMockRecorder is the mock recorder for MockOperatorReader.
+// MockOperatorReaderMockRecorder is the mock recorder for MockOperatorReader
 type MockOperatorReaderMockRecorder struct {
 	mock *MockOperatorReader
 }
 
-// NewMockOperatorReader creates a new mock instance.
+// NewMockOperatorReader creates a new mock instance
 func NewMockOperatorReader(ctrl *gomock.Controller) *MockOperatorReader {
 	mock := &MockOperatorReader{ctrl: ctrl}
 	mock.recorder = &MockOperatorReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockOperatorReader) EXPECT() *MockOperatorReaderMockRecorder {
 	return m.recorder
 }
 
-// GetBackup mocks base method.
-func (m *MockOperatorReader) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackup indicates an expected call of GetBackup.
-func (mr *MockOperatorReaderMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockOperatorReader)(nil).GetBackup), ctx, cluster, name)
-}
-
-// GetBackupEx mocks base method.
-func (m *MockOperatorReader) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupEx indicates an expected call of GetBackupEx.
-func (mr *MockOperatorReaderMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupEx), ctx, cluster, name)
-}
-
-// GetBackupPoint mocks base method.
-func (m *MockOperatorReader) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupPoint indicates an expected call of GetBackupPoint.
-func (mr *MockOperatorReaderMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupPoint), ctx, name, resourceVersion)
-}
-
-// GetBackupPointEx mocks base method.
-func (m *MockOperatorReader) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupPointEx indicates an expected call of GetBackupPointEx.
-func (mr *MockOperatorReaderMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupPointEx), ctx, name, resourceVersion)
-}
-
-// GetCluster mocks base method.
-func (m *MockOperatorReader) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCluster indicates an expected call of GetCluster.
-func (mr *MockOperatorReaderMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperatorReader)(nil).GetCluster), ctx, name)
-}
-
-// GetClusterEx mocks base method.
-func (m *MockOperatorReader) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterEx indicates an expected call of GetClusterEx.
-func (mr *MockOperatorReaderMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).GetClusterEx), ctx, name, resourceVersion)
-}
-
-// GetCronBackup mocks base method.
-func (m *MockOperatorReader) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCronBackup indicates an expected call of GetCronBackup.
-func (mr *MockOperatorReaderMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockOperatorReader)(nil).GetCronBackup), ctx, name, resourceVersion)
-}
-
-// GetCronBackupEx mocks base method.
-func (m *MockOperatorReader) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCronBackupEx indicates an expected call of GetCronBackupEx.
-func (mr *MockOperatorReaderMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).GetCronBackupEx), ctx, name, resourceVersion)
-}
-
-// GetDomain mocks base method.
-func (m *MockOperatorReader) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
-	ret0, _ := ret[0].(*v1.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDomain indicates an expected call of GetDomain.
-func (mr *MockOperatorReaderMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockOperatorReader)(nil).GetDomain), ctx, name)
-}
-
-// GetNode mocks base method.
-func (m *MockOperatorReader) GetNode(ctx context.Context, name string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNode", ctx, name)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNode indicates an expected call of GetNode.
-func (mr *MockOperatorReaderMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperatorReader)(nil).GetNode), ctx, name)
-}
-
-// GetNodeEx mocks base method.
-func (m *MockOperatorReader) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNodeEx indicates an expected call of GetNodeEx.
-func (mr *MockOperatorReaderMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperatorReader)(nil).GetNodeEx), ctx, name, resourceVersion)
-}
-
-// GetRegion mocks base method.
-func (m *MockOperatorReader) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegion indicates an expected call of GetRegion.
-func (mr *MockOperatorReaderMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperatorReader)(nil).GetRegion), ctx, name)
-}
-
-// GetRegionEx mocks base method.
-func (m *MockOperatorReader) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegionEx indicates an expected call of GetRegionEx.
-func (mr *MockOperatorReaderMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).GetRegionEx), ctx, name, resourceVersion)
-}
-
-// ListBackupEx mocks base method.
-func (m *MockOperatorReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupEx indicates an expected call of ListBackupEx.
-func (mr *MockOperatorReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupEx), ctx, query)
-}
-
-// ListBackupPointEx mocks base method.
-func (m *MockOperatorReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPointEx indicates an expected call of ListBackupPointEx.
-func (mr *MockOperatorReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPointEx), ctx, query)
-}
-
-// ListBackupPoints mocks base method.
-func (m *MockOperatorReader) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupPointList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPoints indicates an expected call of ListBackupPoints.
-func (mr *MockOperatorReaderMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPoints), ctx, query)
-}
-
-// ListBackups mocks base method.
-func (m *MockOperatorReader) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackups indicates an expected call of ListBackups.
-func (mr *MockOperatorReaderMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListBackups), ctx, query)
-}
-
-// ListClusterEx mocks base method.
-func (m *MockOperatorReader) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusterEx indicates an expected call of ListClusterEx.
-func (mr *MockOperatorReaderMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).ListClusterEx), ctx, query)
-}
-
-// ListClusters mocks base method.
+// ListClusters mocks base method
 func (m *MockOperatorReader) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
@@ -317,163 +46,13 @@ func (m *MockOperatorReader) ListClusters(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// ListClusters indicates an expected call of ListClusters.
+// ListClusters indicates an expected call of ListClusters
 func (mr *MockOperatorReaderMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockOperatorReader)(nil).ListClusters), ctx, query)
 }
 
-// ListCronBackupEx mocks base method.
-func (m *MockOperatorReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackupEx indicates an expected call of ListCronBackupEx.
-func (mr *MockOperatorReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackupEx), ctx, query)
-}
-
-// ListCronBackups mocks base method.
-func (m *MockOperatorReader) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.CronBackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackups indicates an expected call of ListCronBackups.
-func (mr *MockOperatorReaderMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackups), ctx, query)
-}
-
-// ListDomains mocks base method.
-func (m *MockOperatorReader) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
-	ret0, _ := ret[0].(*v1.DomainList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomains indicates an expected call of ListDomains.
-func (mr *MockOperatorReaderMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperatorReader)(nil).ListDomains), ctx, query)
-}
-
-// ListDomainsEx mocks base method.
-func (m *MockOperatorReader) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomainsEx indicates an expected call of ListDomainsEx.
-func (mr *MockOperatorReaderMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockOperatorReader)(nil).ListDomainsEx), ctx, query)
-}
-
-// ListNodes mocks base method.
-func (m *MockOperatorReader) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
-	ret0, _ := ret[0].(*v1.NodeList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodes indicates an expected call of ListNodes.
-func (mr *MockOperatorReaderMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperatorReader)(nil).ListNodes), ctx, query)
-}
-
-// ListNodesEx mocks base method.
-func (m *MockOperatorReader) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodesEx indicates an expected call of ListNodesEx.
-func (mr *MockOperatorReaderMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperatorReader)(nil).ListNodesEx), ctx, query)
-}
-
-// ListRecordsEx mocks base method.
-func (m *MockOperatorReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecordsEx indicates an expected call of ListRecordsEx.
-func (mr *MockOperatorReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
-}
-
-// ListRegionEx mocks base method.
-func (m *MockOperatorReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegionEx indicates an expected call of ListRegionEx.
-func (mr *MockOperatorReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRegionEx), ctx, query)
-}
-
-// ListRegions mocks base method.
-func (m *MockOperatorReader) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
-	ret0, _ := ret[0].(*v1.RegionList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegions indicates an expected call of ListRegions.
-func (mr *MockOperatorReaderMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperatorReader)(nil).ListRegions), ctx, query)
-}
-
-// WatchBackups mocks base method.
-func (m *MockOperatorReader) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackups indicates an expected call of WatchBackups.
-func (mr *MockOperatorReaderMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperatorReader)(nil).WatchBackups), ctx, query)
-}
-
-// WatchClusters mocks base method.
+// WatchClusters mocks base method
 func (m *MockOperatorReader) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
@@ -482,43 +61,88 @@ func (m *MockOperatorReader) WatchClusters(ctx context.Context, query *query.Que
 	return ret0, ret1
 }
 
-// WatchClusters indicates an expected call of WatchClusters.
+// WatchClusters indicates an expected call of WatchClusters
 func (mr *MockOperatorReaderMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockOperatorReader)(nil).WatchClusters), ctx, query)
 }
 
-// WatchDomain mocks base method.
-func (m *MockOperatorReader) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+// GetCluster mocks base method
+func (m *MockOperatorReader) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
+	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
+	ret0, _ := ret[0].(*v1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchDomain indicates an expected call of WatchDomain.
-func (mr *MockOperatorReaderMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+// GetCluster indicates an expected call of GetCluster
+func (mr *MockOperatorReaderMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperatorReader)(nil).WatchDomain), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperatorReader)(nil).GetCluster), ctx, name)
 }
 
-// WatchNodes mocks base method.
-func (m *MockOperatorReader) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
+// GetClusterEx mocks base method
+func (m *MockOperatorReader) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
+	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchNodes indicates an expected call of WatchNodes.
-func (mr *MockOperatorReaderMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
+// GetClusterEx indicates an expected call of GetClusterEx
+func (mr *MockOperatorReaderMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperatorReader)(nil).WatchNodes), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).GetClusterEx), ctx, name, resourceVersion)
 }
 
-// WatchRegions mocks base method.
+// ListClusterEx mocks base method
+func (m *MockOperatorReader) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusterEx indicates an expected call of ListClusterEx
+func (mr *MockOperatorReaderMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).ListClusterEx), ctx, query)
+}
+
+// ListRegions mocks base method
+func (m *MockOperatorReader) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
+	ret0, _ := ret[0].(*v1.RegionList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegions indicates an expected call of ListRegions
+func (mr *MockOperatorReaderMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperatorReader)(nil).ListRegions), ctx, query)
+}
+
+// GetRegion mocks base method
+func (m *MockOperatorReader) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegion indicates an expected call of GetRegion
+func (mr *MockOperatorReaderMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperatorReader)(nil).GetRegion), ctx, name)
+}
+
+// WatchRegions mocks base method
 func (m *MockOperatorReader) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
@@ -527,66 +151,441 @@ func (m *MockOperatorReader) WatchRegions(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// WatchRegions indicates an expected call of WatchRegions.
+// WatchRegions indicates an expected call of WatchRegions
 func (mr *MockOperatorReaderMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockOperatorReader)(nil).WatchRegions), ctx, query)
 }
 
-// MockOperatorWriter is a mock of OperatorWriter interface.
+// ListRegionEx mocks base method
+func (m *MockOperatorReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegionEx indicates an expected call of ListRegionEx
+func (mr *MockOperatorReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRegionEx), ctx, query)
+}
+
+// GetRegionEx mocks base method
+func (m *MockOperatorReader) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegionEx indicates an expected call of GetRegionEx
+func (mr *MockOperatorReaderMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).GetRegionEx), ctx, name, resourceVersion)
+}
+
+// ListNodes mocks base method
+func (m *MockOperatorReader) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
+	ret0, _ := ret[0].(*v1.NodeList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodes indicates an expected call of ListNodes
+func (mr *MockOperatorReaderMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperatorReader)(nil).ListNodes), ctx, query)
+}
+
+// WatchNodes mocks base method
+func (m *MockOperatorReader) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchNodes indicates an expected call of WatchNodes
+func (mr *MockOperatorReaderMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperatorReader)(nil).WatchNodes), ctx, query)
+}
+
+// GetNode mocks base method
+func (m *MockOperatorReader) GetNode(ctx context.Context, name string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNode", ctx, name)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNode indicates an expected call of GetNode
+func (mr *MockOperatorReaderMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperatorReader)(nil).GetNode), ctx, name)
+}
+
+// GetNodeEx mocks base method
+func (m *MockOperatorReader) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeEx indicates an expected call of GetNodeEx
+func (mr *MockOperatorReaderMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperatorReader)(nil).GetNodeEx), ctx, name, resourceVersion)
+}
+
+// ListNodesEx mocks base method
+func (m *MockOperatorReader) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodesEx indicates an expected call of ListNodesEx
+func (mr *MockOperatorReaderMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperatorReader)(nil).ListNodesEx), ctx, query)
+}
+
+// ListBackups mocks base method
+func (m *MockOperatorReader) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackups indicates an expected call of ListBackups
+func (mr *MockOperatorReaderMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListBackups), ctx, query)
+}
+
+// WatchBackups mocks base method
+func (m *MockOperatorReader) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackups indicates an expected call of WatchBackups
+func (mr *MockOperatorReaderMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperatorReader)(nil).WatchBackups), ctx, query)
+}
+
+// GetBackup mocks base method
+func (m *MockOperatorReader) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackup indicates an expected call of GetBackup
+func (mr *MockOperatorReaderMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockOperatorReader)(nil).GetBackup), ctx, cluster, name)
+}
+
+// ListBackupEx mocks base method
+func (m *MockOperatorReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupEx indicates an expected call of ListBackupEx
+func (mr *MockOperatorReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupEx), ctx, query)
+}
+
+// GetBackupEx mocks base method
+func (m *MockOperatorReader) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupEx indicates an expected call of GetBackupEx
+func (mr *MockOperatorReaderMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupEx), ctx, cluster, name)
+}
+
+// ListBackupPoints mocks base method
+func (m *MockOperatorReader) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupPointList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPoints indicates an expected call of ListBackupPoints
+func (mr *MockOperatorReaderMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPoints), ctx, query)
+}
+
+// GetBackupPoint mocks base method
+func (m *MockOperatorReader) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPoint indicates an expected call of GetBackupPoint
+func (mr *MockOperatorReaderMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupPoint), ctx, name, resourceVersion)
+}
+
+// WatchBackupPoints mocks base method
+func (m *MockOperatorReader) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackupPoints indicates an expected call of WatchBackupPoints
+func (mr *MockOperatorReaderMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockOperatorReader)(nil).WatchBackupPoints), ctx, query)
+}
+
+// ListBackupPointEx mocks base method
+func (m *MockOperatorReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPointEx indicates an expected call of ListBackupPointEx
+func (mr *MockOperatorReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPointEx), ctx, query)
+}
+
+// GetBackupPointEx mocks base method
+func (m *MockOperatorReader) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPointEx indicates an expected call of GetBackupPointEx
+func (mr *MockOperatorReaderMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupPointEx), ctx, name, resourceVersion)
+}
+
+// ListCronBackups mocks base method
+func (m *MockOperatorReader) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.CronBackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackups indicates an expected call of ListCronBackups
+func (mr *MockOperatorReaderMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackups), ctx, query)
+}
+
+// GetCronBackup mocks base method
+func (m *MockOperatorReader) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackup indicates an expected call of GetCronBackup
+func (mr *MockOperatorReaderMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockOperatorReader)(nil).GetCronBackup), ctx, name, resourceVersion)
+}
+
+// WatchCronBackups mocks base method
+func (m *MockOperatorReader) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchCronBackups indicates an expected call of WatchCronBackups
+func (mr *MockOperatorReaderMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockOperatorReader)(nil).WatchCronBackups), ctx, query)
+}
+
+// ListCronBackupEx mocks base method
+func (m *MockOperatorReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackupEx indicates an expected call of ListCronBackupEx
+func (mr *MockOperatorReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackupEx), ctx, query)
+}
+
+// GetCronBackupEx mocks base method
+func (m *MockOperatorReader) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackupEx indicates an expected call of GetCronBackupEx
+func (mr *MockOperatorReaderMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).GetCronBackupEx), ctx, name, resourceVersion)
+}
+
+// ListDomains mocks base method
+func (m *MockOperatorReader) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
+	ret0, _ := ret[0].(*v1.DomainList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomains indicates an expected call of ListDomains
+func (mr *MockOperatorReaderMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperatorReader)(nil).ListDomains), ctx, query)
+}
+
+// GetDomain mocks base method
+func (m *MockOperatorReader) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
+	ret0, _ := ret[0].(*v1.Domain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDomain indicates an expected call of GetDomain
+func (mr *MockOperatorReaderMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockOperatorReader)(nil).GetDomain), ctx, name)
+}
+
+// WatchDomain mocks base method
+func (m *MockOperatorReader) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchDomain indicates an expected call of WatchDomain
+func (mr *MockOperatorReaderMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperatorReader)(nil).WatchDomain), ctx, query)
+}
+
+// ListRecordsEx mocks base method
+func (m *MockOperatorReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRecordsEx indicates an expected call of ListRecordsEx
+func (mr *MockOperatorReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
+}
+
+// ListDomainsEx mocks base method
+func (m *MockOperatorReader) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomainsEx indicates an expected call of ListDomainsEx
+func (mr *MockOperatorReaderMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockOperatorReader)(nil).ListDomainsEx), ctx, query)
+}
+
+// MockOperatorWriter is a mock of OperatorWriter interface
 type MockOperatorWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockOperatorWriterMockRecorder
 }
 
-// MockOperatorWriterMockRecorder is the mock recorder for MockOperatorWriter.
+// MockOperatorWriterMockRecorder is the mock recorder for MockOperatorWriter
 type MockOperatorWriterMockRecorder struct {
 	mock *MockOperatorWriter
 }
 
-// NewMockOperatorWriter creates a new mock instance.
+// NewMockOperatorWriter creates a new mock instance
 func NewMockOperatorWriter(ctrl *gomock.Controller) *MockOperatorWriter {
 	mock := &MockOperatorWriter{ctrl: ctrl}
 	mock.recorder = &MockOperatorWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockOperatorWriter) EXPECT() *MockOperatorWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateBackup mocks base method.
-func (m *MockOperatorWriter) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateBackup indicates an expected call of CreateBackup.
-func (mr *MockOperatorWriterMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockOperatorWriter)(nil).CreateBackup), ctc, backup)
-}
-
-// CreateBackupPoint mocks base method.
-func (m *MockOperatorWriter) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateBackupPoint indicates an expected call of CreateBackupPoint.
-func (mr *MockOperatorWriterMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).CreateBackupPoint), ctx, backupPoint)
-}
-
-// CreateCluster mocks base method.
+// CreateCluster mocks base method
 func (m *MockOperatorWriter) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
@@ -595,201 +594,13 @@ func (m *MockOperatorWriter) CreateCluster(ctx context.Context, cluster *v1.Clus
 	return ret0, ret1
 }
 
-// CreateCluster indicates an expected call of CreateCluster.
+// CreateCluster indicates an expected call of CreateCluster
 func (mr *MockOperatorWriterMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockOperatorWriter)(nil).CreateCluster), ctx, cluster)
 }
 
-// CreateCronBackup mocks base method.
-func (m *MockOperatorWriter) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCronBackup indicates an expected call of CreateCronBackup.
-func (mr *MockOperatorWriterMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).CreateCronBackup), ctx, cronBackup)
-}
-
-// CreateDomain mocks base method.
-func (m *MockOperatorWriter) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
-	ret0, _ := ret[0].(*v1.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateDomain indicates an expected call of CreateDomain.
-func (mr *MockOperatorWriterMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockOperatorWriter)(nil).CreateDomain), ctc, domain)
-}
-
-// CreateNode mocks base method.
-func (m *MockOperatorWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateNode indicates an expected call of CreateNode.
-func (mr *MockOperatorWriterMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperatorWriter)(nil).CreateNode), ctx, node)
-}
-
-// CreateRegion mocks base method.
-func (m *MockOperatorWriter) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateRegion indicates an expected call of CreateRegion.
-func (mr *MockOperatorWriterMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperatorWriter)(nil).CreateRegion), ctx, region)
-}
-
-// DeleteBackup mocks base method.
-func (m *MockOperatorWriter) DeleteBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackup indicates an expected call of DeleteBackup.
-func (mr *MockOperatorWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackup), ctx, name)
-}
-
-// DeleteBackupPoint mocks base method.
-func (m *MockOperatorWriter) DeleteBackupPoint(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackupPoint indicates an expected call of DeleteBackupPoint.
-func (mr *MockOperatorWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackupPoint), ctx, name)
-}
-
-// DeleteCluster mocks base method.
-func (m *MockOperatorWriter) DeleteCluster(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCluster indicates an expected call of DeleteCluster.
-func (mr *MockOperatorWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCluster), ctx, name)
-}
-
-// DeleteCronBackup mocks base method.
-func (m *MockOperatorWriter) DeleteCronBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCronBackup indicates an expected call of DeleteCronBackup.
-func (mr *MockOperatorWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCronBackup), ctx, name)
-}
-
-// DeleteDomain mocks base method.
-func (m *MockOperatorWriter) DeleteDomain(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteDomain indicates an expected call of DeleteDomain.
-func (mr *MockOperatorWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteDomain), ctx, name)
-}
-
-// DeleteNode mocks base method.
-func (m *MockOperatorWriter) DeleteNode(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteNode indicates an expected call of DeleteNode.
-func (mr *MockOperatorWriterMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteNode), ctx, name)
-}
-
-// DeleteRegion mocks base method.
-func (m *MockOperatorWriter) DeleteRegion(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRegion indicates an expected call of DeleteRegion.
-func (mr *MockOperatorWriterMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteRegion), ctx, name)
-}
-
-// UpdateBackup mocks base method.
-func (m *MockOperatorWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateBackup indicates an expected call of UpdateBackup.
-func (mr *MockOperatorWriterMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackup), ctx, backup)
-}
-
-// UpdateBackupPoint mocks base method.
-func (m *MockOperatorWriter) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateBackupPoint indicates an expected call of UpdateBackupPoint.
-func (mr *MockOperatorWriterMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackupPoint), ctx, backupPoint)
-}
-
-// UpdateCluster mocks base method.
+// UpdateCluster mocks base method
 func (m *MockOperatorWriter) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
@@ -798,43 +609,56 @@ func (m *MockOperatorWriter) UpdateCluster(ctx context.Context, cluster *v1.Clus
 	return ret0, ret1
 }
 
-// UpdateCluster indicates an expected call of UpdateCluster.
+// UpdateCluster indicates an expected call of UpdateCluster
 func (mr *MockOperatorWriterMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateCluster), ctx, cluster)
 }
 
-// UpdateCronBackup mocks base method.
-func (m *MockOperatorWriter) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
+// DeleteCluster mocks base method
+func (m *MockOperatorWriter) DeleteCluster(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
-	ret0, _ := ret[0].(*v1.CronBackup)
+	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCluster indicates an expected call of DeleteCluster
+func (mr *MockOperatorWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCluster), ctx, name)
+}
+
+// CreateRegion mocks base method
+func (m *MockOperatorWriter) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
+	ret0, _ := ret[0].(*v1.Region)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateCronBackup indicates an expected call of UpdateCronBackup.
-func (mr *MockOperatorWriterMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
+// CreateRegion indicates an expected call of CreateRegion
+func (mr *MockOperatorWriterMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateCronBackup), ctx, cronBackup)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperatorWriter)(nil).CreateRegion), ctx, region)
 }
 
-// UpdateDomain mocks base method.
-func (m *MockOperatorWriter) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
+// DeleteRegion mocks base method
+func (m *MockOperatorWriter) DeleteRegion(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
-	ret0, _ := ret[0].(*v1.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// UpdateDomain indicates an expected call of UpdateDomain.
-func (mr *MockOperatorWriterMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
+// DeleteRegion indicates an expected call of DeleteRegion
+func (mr *MockOperatorWriterMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateDomain), ctx, domain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteRegion), ctx, name)
 }
 
-// UpdateNode mocks base method.
+// UpdateNode mocks base method
 func (m *MockOperatorWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
@@ -843,112 +667,14 @@ func (m *MockOperatorWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1
 	return ret0, ret1
 }
 
-// UpdateNode indicates an expected call of UpdateNode.
+// UpdateNode indicates an expected call of UpdateNode
 func (mr *MockOperatorWriterMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateNode), ctx, node)
 }
 
-// MockOperator is a mock of Operator interface.
-type MockOperator struct {
-	ctrl     *gomock.Controller
-	recorder *MockOperatorMockRecorder
-}
-
-// MockOperatorMockRecorder is the mock recorder for MockOperator.
-type MockOperatorMockRecorder struct {
-	mock *MockOperator
-}
-
-// NewMockOperator creates a new mock instance.
-func NewMockOperator(ctrl *gomock.Controller) *MockOperator {
-	mock := &MockOperator{ctrl: ctrl}
-	mock.recorder = &MockOperatorMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
-	return m.recorder
-}
-
-// CreateBackup mocks base method.
-func (m *MockOperator) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateBackup indicates an expected call of CreateBackup.
-func (mr *MockOperatorMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockOperator)(nil).CreateBackup), ctc, backup)
-}
-
-// CreateBackupPoint mocks base method.
-func (m *MockOperator) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateBackupPoint indicates an expected call of CreateBackupPoint.
-func (mr *MockOperatorMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockOperator)(nil).CreateBackupPoint), ctx, backupPoint)
-}
-
-// CreateCluster mocks base method.
-func (m *MockOperator) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCluster indicates an expected call of CreateCluster.
-func (mr *MockOperatorMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockOperator)(nil).CreateCluster), ctx, cluster)
-}
-
-// CreateCronBackup mocks base method.
-func (m *MockOperator) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCronBackup indicates an expected call of CreateCronBackup.
-func (mr *MockOperatorMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockOperator)(nil).CreateCronBackup), ctx, cronBackup)
-}
-
-// CreateDomain mocks base method.
-func (m *MockOperator) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
-	ret0, _ := ret[0].(*v1.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateDomain indicates an expected call of CreateDomain.
-func (mr *MockOperatorMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockOperator)(nil).CreateDomain), ctc, domain)
-}
-
-// CreateNode mocks base method.
-func (m *MockOperator) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+// CreateNode mocks base method
+func (m *MockOperatorWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
 	ret0, _ := ret[0].(*v1.Node)
@@ -956,469 +682,226 @@ func (m *MockOperator) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node,
 	return ret0, ret1
 }
 
-// CreateNode indicates an expected call of CreateNode.
-func (mr *MockOperatorMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
+// CreateNode indicates an expected call of CreateNode
+func (mr *MockOperatorWriterMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperator)(nil).CreateNode), ctx, node)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperatorWriter)(nil).CreateNode), ctx, node)
 }
 
-// CreateRegion mocks base method.
-func (m *MockOperator) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateRegion indicates an expected call of CreateRegion.
-func (mr *MockOperatorMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperator)(nil).CreateRegion), ctx, region)
-}
-
-// CreateTemplate mocks base method.
-func (m *MockOperator) CreateTemplate(ctc context.Context, template *v1.Template) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTemplate", ctc, template)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateTemplate indicates an expected call of CreateTemplate.
-func (mr *MockOperatorMockRecorder) CreateTemplate(ctc, template interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTemplate", reflect.TypeOf((*MockOperator)(nil).CreateTemplate), ctc, template)
-}
-
-// DeleteBackup mocks base method.
-func (m *MockOperator) DeleteBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackup indicates an expected call of DeleteBackup.
-func (mr *MockOperatorMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperator)(nil).DeleteBackup), ctx, name)
-}
-
-// DeleteBackupPoint mocks base method.
-func (m *MockOperator) DeleteBackupPoint(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackupPoint indicates an expected call of DeleteBackupPoint.
-func (mr *MockOperatorMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperator)(nil).DeleteBackupPoint), ctx, name)
-}
-
-// DeleteCluster mocks base method.
-func (m *MockOperator) DeleteCluster(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCluster indicates an expected call of DeleteCluster.
-func (mr *MockOperatorMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperator)(nil).DeleteCluster), ctx, name)
-}
-
-// DeleteCronBackup mocks base method.
-func (m *MockOperator) DeleteCronBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCronBackup indicates an expected call of DeleteCronBackup.
-func (mr *MockOperatorMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperator)(nil).DeleteCronBackup), ctx, name)
-}
-
-// DeleteDomain mocks base method.
-func (m *MockOperator) DeleteDomain(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteDomain indicates an expected call of DeleteDomain.
-func (mr *MockOperatorMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperator)(nil).DeleteDomain), ctx, name)
-}
-
-// DeleteNode mocks base method.
-func (m *MockOperator) DeleteNode(ctx context.Context, name string) error {
+// DeleteNode mocks base method
+func (m *MockOperatorWriter) DeleteNode(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteNode indicates an expected call of DeleteNode.
-func (mr *MockOperatorMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
+// DeleteNode indicates an expected call of DeleteNode
+func (mr *MockOperatorWriterMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperator)(nil).DeleteNode), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteNode), ctx, name)
 }
 
-// DeleteRegion mocks base method.
-func (m *MockOperator) DeleteRegion(ctx context.Context, name string) error {
+// CreateBackup mocks base method
+func (m *MockOperatorWriter) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRegion indicates an expected call of DeleteRegion.
-func (mr *MockOperatorMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperator)(nil).DeleteRegion), ctx, name)
-}
-
-// DeleteTemplate mocks base method.
-func (m *MockOperator) DeleteTemplate(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplate indicates an expected call of DeleteTemplate.
-func (mr *MockOperatorMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockOperator)(nil).DeleteTemplate), ctx, name)
-}
-
-// DeleteTemplateCollection mocks base method.
-func (m *MockOperator) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection.
-func (mr *MockOperatorMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockOperator)(nil).DeleteTemplateCollection), ctx, query)
-}
-
-// GetBackup mocks base method.
-func (m *MockOperator) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
+	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
 	ret0, _ := ret[0].(*v1.Backup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBackup indicates an expected call of GetBackup.
-func (mr *MockOperatorMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
+// CreateBackup indicates an expected call of CreateBackup
+func (mr *MockOperatorWriterMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockOperator)(nil).GetBackup), ctx, cluster, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockOperatorWriter)(nil).CreateBackup), ctc, backup)
 }
 
-// GetBackupEx mocks base method.
-func (m *MockOperator) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+// UpdateBackup mocks base method
+func (m *MockOperatorWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
+	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
 	ret0, _ := ret[0].(*v1.Backup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBackupEx indicates an expected call of GetBackupEx.
-func (mr *MockOperatorMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
+// UpdateBackup indicates an expected call of UpdateBackup
+func (mr *MockOperatorWriterMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockOperator)(nil).GetBackupEx), ctx, cluster, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackup), ctx, backup)
 }
 
-// GetBackupPoint mocks base method.
-func (m *MockOperator) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+// DeleteBackup mocks base method
+func (m *MockOperatorWriter) DeleteBackup(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
+	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackup indicates an expected call of DeleteBackup
+func (mr *MockOperatorWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackup), ctx, name)
+}
+
+// CreateBackupPoint mocks base method
+func (m *MockOperatorWriter) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
 	ret0, _ := ret[0].(*v1.BackupPoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBackupPoint indicates an expected call of GetBackupPoint.
-func (mr *MockOperatorMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
+// CreateBackupPoint indicates an expected call of CreateBackupPoint
+func (mr *MockOperatorWriterMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockOperator)(nil).GetBackupPoint), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).CreateBackupPoint), ctx, backupPoint)
 }
 
-// GetBackupPointEx mocks base method.
-func (m *MockOperator) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+// UpdateBackupPoint mocks base method
+func (m *MockOperatorWriter) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
+	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
 	ret0, _ := ret[0].(*v1.BackupPoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBackupPointEx indicates an expected call of GetBackupPointEx.
-func (mr *MockOperatorMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+// UpdateBackupPoint indicates an expected call of UpdateBackupPoint
+func (mr *MockOperatorWriterMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockOperator)(nil).GetBackupPointEx), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackupPoint), ctx, backupPoint)
 }
 
-// GetCluster mocks base method.
-func (m *MockOperator) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
+// DeleteBackupPoint mocks base method
+func (m *MockOperatorWriter) DeleteBackupPoint(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetCluster indicates an expected call of GetCluster.
-func (mr *MockOperatorMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
+// DeleteBackupPoint indicates an expected call of DeleteBackupPoint
+func (mr *MockOperatorWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperator)(nil).GetCluster), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackupPoint), ctx, name)
 }
 
-// GetClusterEx mocks base method.
-func (m *MockOperator) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
+// CreateCronBackup mocks base method
+func (m *MockOperatorWriter) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterEx indicates an expected call of GetClusterEx.
-func (mr *MockOperatorMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperator)(nil).GetClusterEx), ctx, name, resourceVersion)
-}
-
-// GetCronBackup mocks base method.
-func (m *MockOperator) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
+	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
 	ret0, _ := ret[0].(*v1.CronBackup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetCronBackup indicates an expected call of GetCronBackup.
-func (mr *MockOperatorMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
+// CreateCronBackup indicates an expected call of CreateCronBackup
+func (mr *MockOperatorWriterMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockOperator)(nil).GetCronBackup), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).CreateCronBackup), ctx, cronBackup)
 }
 
-// GetCronBackupEx mocks base method.
-func (m *MockOperator) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+// UpdateCronBackup mocks base method
+func (m *MockOperatorWriter) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
+	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
 	ret0, _ := ret[0].(*v1.CronBackup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetCronBackupEx indicates an expected call of GetCronBackupEx.
-func (mr *MockOperatorMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+// UpdateCronBackup indicates an expected call of UpdateCronBackup
+func (mr *MockOperatorWriterMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockOperator)(nil).GetCronBackupEx), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateCronBackup), ctx, cronBackup)
 }
 
-// GetDomain mocks base method.
-func (m *MockOperator) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
+// DeleteCronBackup mocks base method
+func (m *MockOperatorWriter) DeleteCronBackup(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
+	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackup indicates an expected call of DeleteCronBackup
+func (mr *MockOperatorWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCronBackup), ctx, name)
+}
+
+// CreateDomain mocks base method
+func (m *MockOperatorWriter) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
 	ret0, _ := ret[0].(*v1.Domain)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDomain indicates an expected call of GetDomain.
-func (mr *MockOperatorMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
+// CreateDomain indicates an expected call of CreateDomain
+func (mr *MockOperatorWriterMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockOperator)(nil).GetDomain), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockOperatorWriter)(nil).CreateDomain), ctc, domain)
 }
 
-// GetNode mocks base method.
-func (m *MockOperator) GetNode(ctx context.Context, name string) (*v1.Node, error) {
+// UpdateDomain mocks base method
+func (m *MockOperatorWriter) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNode", ctx, name)
-	ret0, _ := ret[0].(*v1.Node)
+	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
+	ret0, _ := ret[0].(*v1.Domain)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetNode indicates an expected call of GetNode.
-func (mr *MockOperatorMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
+// UpdateDomain indicates an expected call of UpdateDomain
+func (mr *MockOperatorWriterMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperator)(nil).GetNode), ctx, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateDomain), ctx, domain)
 }
 
-// GetNodeEx mocks base method.
-func (m *MockOperator) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
+// DeleteDomain mocks base method
+func (m *MockOperatorWriter) DeleteDomain(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetNodeEx indicates an expected call of GetNodeEx.
-func (mr *MockOperatorMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+// DeleteDomain indicates an expected call of DeleteDomain
+func (mr *MockOperatorWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperator)(nil).GetNodeEx), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteDomain), ctx, name)
 }
 
-// GetRegion mocks base method.
-func (m *MockOperator) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+// MockOperator is a mock of Operator interface
+type MockOperator struct {
+	ctrl     *gomock.Controller
+	recorder *MockOperatorMockRecorder
 }
 
-// GetRegion indicates an expected call of GetRegion.
-func (mr *MockOperatorMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperator)(nil).GetRegion), ctx, name)
+// MockOperatorMockRecorder is the mock recorder for MockOperator
+type MockOperatorMockRecorder struct {
+	mock *MockOperator
 }
 
-// GetRegionEx mocks base method.
-func (m *MockOperator) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+// NewMockOperator creates a new mock instance
+func NewMockOperator(ctrl *gomock.Controller) *MockOperator {
+	mock := &MockOperator{ctrl: ctrl}
+	mock.recorder = &MockOperatorMockRecorder{mock}
+	return mock
 }
 
-// GetRegionEx indicates an expected call of GetRegionEx.
-func (mr *MockOperatorMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperator)(nil).GetRegionEx), ctx, name, resourceVersion)
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
+	return m.recorder
 }
 
-// GetTemplate mocks base method.
-func (m *MockOperator) GetTemplate(ctx context.Context, name string) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplate", ctx, name)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTemplate indicates an expected call of GetTemplate.
-func (mr *MockOperatorMockRecorder) GetTemplate(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockOperator)(nil).GetTemplate), ctx, name)
-}
-
-// GetTemplateEx mocks base method.
-func (m *MockOperator) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTemplateEx indicates an expected call of GetTemplateEx.
-func (mr *MockOperatorMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockOperator)(nil).GetTemplateEx), ctx, name, resourceVersion)
-}
-
-// ListBackupEx mocks base method.
-func (m *MockOperator) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupEx indicates an expected call of ListBackupEx.
-func (mr *MockOperatorMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperator)(nil).ListBackupEx), ctx, query)
-}
-
-// ListBackupPointEx mocks base method.
-func (m *MockOperator) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPointEx indicates an expected call of ListBackupPointEx.
-func (mr *MockOperatorMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperator)(nil).ListBackupPointEx), ctx, query)
-}
-
-// ListBackupPoints mocks base method.
-func (m *MockOperator) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupPointList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPoints indicates an expected call of ListBackupPoints.
-func (mr *MockOperatorMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperator)(nil).ListBackupPoints), ctx, query)
-}
-
-// ListBackups mocks base method.
-func (m *MockOperator) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackups indicates an expected call of ListBackups.
-func (mr *MockOperatorMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperator)(nil).ListBackups), ctx, query)
-}
-
-// ListClusterEx mocks base method.
-func (m *MockOperator) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusterEx indicates an expected call of ListClusterEx.
-func (mr *MockOperatorMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperator)(nil).ListClusterEx), ctx, query)
-}
-
-// ListClusters mocks base method.
+// ListClusters mocks base method
 func (m *MockOperator) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
@@ -1427,298 +910,13 @@ func (m *MockOperator) ListClusters(ctx context.Context, query *query.Query) (*v
 	return ret0, ret1
 }
 
-// ListClusters indicates an expected call of ListClusters.
+// ListClusters indicates an expected call of ListClusters
 func (mr *MockOperatorMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockOperator)(nil).ListClusters), ctx, query)
 }
 
-// ListCronBackupEx mocks base method.
-func (m *MockOperator) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackupEx indicates an expected call of ListCronBackupEx.
-func (mr *MockOperatorMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperator)(nil).ListCronBackupEx), ctx, query)
-}
-
-// ListCronBackups mocks base method.
-func (m *MockOperator) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.CronBackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackups indicates an expected call of ListCronBackups.
-func (mr *MockOperatorMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperator)(nil).ListCronBackups), ctx, query)
-}
-
-// ListDomains mocks base method.
-func (m *MockOperator) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
-	ret0, _ := ret[0].(*v1.DomainList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomains indicates an expected call of ListDomains.
-func (mr *MockOperatorMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperator)(nil).ListDomains), ctx, query)
-}
-
-// ListDomainsEx mocks base method.
-func (m *MockOperator) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomainsEx indicates an expected call of ListDomainsEx.
-func (mr *MockOperatorMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockOperator)(nil).ListDomainsEx), ctx, query)
-}
-
-// ListNodes mocks base method.
-func (m *MockOperator) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
-	ret0, _ := ret[0].(*v1.NodeList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodes indicates an expected call of ListNodes.
-func (mr *MockOperatorMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperator)(nil).ListNodes), ctx, query)
-}
-
-// ListNodesEx mocks base method.
-func (m *MockOperator) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodesEx indicates an expected call of ListNodesEx.
-func (mr *MockOperatorMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperator)(nil).ListNodesEx), ctx, query)
-}
-
-// ListRecordsEx mocks base method.
-func (m *MockOperator) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecordsEx indicates an expected call of ListRecordsEx.
-func (mr *MockOperatorMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperator)(nil).ListRecordsEx), ctx, name, subdomain, query)
-}
-
-// ListRegionEx mocks base method.
-func (m *MockOperator) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegionEx indicates an expected call of ListRegionEx.
-func (mr *MockOperatorMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperator)(nil).ListRegionEx), ctx, query)
-}
-
-// ListRegions mocks base method.
-func (m *MockOperator) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
-	ret0, _ := ret[0].(*v1.RegionList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegions indicates an expected call of ListRegions.
-func (mr *MockOperatorMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperator)(nil).ListRegions), ctx, query)
-}
-
-// ListTemplates mocks base method.
-func (m *MockOperator) ListTemplates(ctx context.Context, query *query.Query) (*v1.TemplateList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTemplates", ctx, query)
-	ret0, _ := ret[0].(*v1.TemplateList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTemplates indicates an expected call of ListTemplates.
-func (mr *MockOperatorMockRecorder) ListTemplates(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplates", reflect.TypeOf((*MockOperator)(nil).ListTemplates), ctx, query)
-}
-
-// ListTemplatesEx mocks base method.
-func (m *MockOperator) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTemplatesEx indicates an expected call of ListTemplatesEx.
-func (mr *MockOperatorMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockOperator)(nil).ListTemplatesEx), ctx, query)
-}
-
-// UpdateBackup mocks base method.
-func (m *MockOperator) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateBackup indicates an expected call of UpdateBackup.
-func (mr *MockOperatorMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperator)(nil).UpdateBackup), ctx, backup)
-}
-
-// UpdateBackupPoint mocks base method.
-func (m *MockOperator) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateBackupPoint indicates an expected call of UpdateBackupPoint.
-func (mr *MockOperatorMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperator)(nil).UpdateBackupPoint), ctx, backupPoint)
-}
-
-// UpdateCluster mocks base method.
-func (m *MockOperator) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateCluster indicates an expected call of UpdateCluster.
-func (mr *MockOperatorMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOperator)(nil).UpdateCluster), ctx, cluster)
-}
-
-// UpdateCronBackup mocks base method.
-func (m *MockOperator) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateCronBackup indicates an expected call of UpdateCronBackup.
-func (mr *MockOperatorMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperator)(nil).UpdateCronBackup), ctx, cronBackup)
-}
-
-// UpdateDomain mocks base method.
-func (m *MockOperator) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
-	ret0, _ := ret[0].(*v1.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateDomain indicates an expected call of UpdateDomain.
-func (mr *MockOperatorMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockOperator)(nil).UpdateDomain), ctx, domain)
-}
-
-// UpdateNode mocks base method.
-func (m *MockOperator) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateNode indicates an expected call of UpdateNode.
-func (mr *MockOperatorMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockOperator)(nil).UpdateNode), ctx, node)
-}
-
-// UpdateTemplate mocks base method.
-func (m *MockOperator) UpdateTemplate(ctx context.Context, template *v1.Template) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTemplate", ctx, template)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateTemplate indicates an expected call of UpdateTemplate.
-func (mr *MockOperatorMockRecorder) UpdateTemplate(ctx, template interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplate", reflect.TypeOf((*MockOperator)(nil).UpdateTemplate), ctx, template)
-}
-
-// WatchBackups mocks base method.
-func (m *MockOperator) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackups indicates an expected call of WatchBackups.
-func (mr *MockOperatorMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperator)(nil).WatchBackups), ctx, query)
-}
-
-// WatchClusters mocks base method.
+// WatchClusters mocks base method
 func (m *MockOperator) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
@@ -1727,43 +925,132 @@ func (m *MockOperator) WatchClusters(ctx context.Context, query *query.Query) (w
 	return ret0, ret1
 }
 
-// WatchClusters indicates an expected call of WatchClusters.
+// WatchClusters indicates an expected call of WatchClusters
 func (mr *MockOperatorMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockOperator)(nil).WatchClusters), ctx, query)
 }
 
-// WatchDomain mocks base method.
-func (m *MockOperator) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+// GetCluster mocks base method
+func (m *MockOperator) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
+	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
+	ret0, _ := ret[0].(*v1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchDomain indicates an expected call of WatchDomain.
-func (mr *MockOperatorMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+// GetCluster indicates an expected call of GetCluster
+func (mr *MockOperatorMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperator)(nil).WatchDomain), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperator)(nil).GetCluster), ctx, name)
 }
 
-// WatchNodes mocks base method.
-func (m *MockOperator) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
+// GetClusterEx mocks base method
+func (m *MockOperator) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
+	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchNodes indicates an expected call of WatchNodes.
-func (mr *MockOperatorMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
+// GetClusterEx indicates an expected call of GetClusterEx
+func (mr *MockOperatorMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperator)(nil).WatchNodes), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperator)(nil).GetClusterEx), ctx, name, resourceVersion)
 }
 
-// WatchRegions mocks base method.
+// ListClusterEx mocks base method
+func (m *MockOperator) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusterEx indicates an expected call of ListClusterEx
+func (mr *MockOperatorMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperator)(nil).ListClusterEx), ctx, query)
+}
+
+// CreateCluster mocks base method
+func (m *MockOperator) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateCluster indicates an expected call of CreateCluster
+func (mr *MockOperatorMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockOperator)(nil).CreateCluster), ctx, cluster)
+}
+
+// UpdateCluster mocks base method
+func (m *MockOperator) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCluster indicates an expected call of UpdateCluster
+func (mr *MockOperatorMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOperator)(nil).UpdateCluster), ctx, cluster)
+}
+
+// DeleteCluster mocks base method
+func (m *MockOperator) DeleteCluster(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCluster indicates an expected call of DeleteCluster
+func (mr *MockOperatorMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperator)(nil).DeleteCluster), ctx, name)
+}
+
+// ListRegions mocks base method
+func (m *MockOperator) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
+	ret0, _ := ret[0].(*v1.RegionList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegions indicates an expected call of ListRegions
+func (mr *MockOperatorMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperator)(nil).ListRegions), ctx, query)
+}
+
+// GetRegion mocks base method
+func (m *MockOperator) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegion indicates an expected call of GetRegion
+func (mr *MockOperatorMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperator)(nil).GetRegion), ctx, name)
+}
+
+// WatchRegions mocks base method
 func (m *MockOperator) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
@@ -1772,13 +1059,682 @@ func (m *MockOperator) WatchRegions(ctx context.Context, query *query.Query) (wa
 	return ret0, ret1
 }
 
-// WatchRegions indicates an expected call of WatchRegions.
+// WatchRegions indicates an expected call of WatchRegions
 func (mr *MockOperatorMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockOperator)(nil).WatchRegions), ctx, query)
 }
 
-// WatchTemplates mocks base method.
+// ListRegionEx mocks base method
+func (m *MockOperator) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegionEx indicates an expected call of ListRegionEx
+func (mr *MockOperatorMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperator)(nil).ListRegionEx), ctx, query)
+}
+
+// GetRegionEx mocks base method
+func (m *MockOperator) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegionEx indicates an expected call of GetRegionEx
+func (mr *MockOperatorMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperator)(nil).GetRegionEx), ctx, name, resourceVersion)
+}
+
+// CreateRegion mocks base method
+func (m *MockOperator) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRegion indicates an expected call of CreateRegion
+func (mr *MockOperatorMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperator)(nil).CreateRegion), ctx, region)
+}
+
+// DeleteRegion mocks base method
+func (m *MockOperator) DeleteRegion(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRegion indicates an expected call of DeleteRegion
+func (mr *MockOperatorMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperator)(nil).DeleteRegion), ctx, name)
+}
+
+// ListNodes mocks base method
+func (m *MockOperator) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
+	ret0, _ := ret[0].(*v1.NodeList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodes indicates an expected call of ListNodes
+func (mr *MockOperatorMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperator)(nil).ListNodes), ctx, query)
+}
+
+// WatchNodes mocks base method
+func (m *MockOperator) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchNodes indicates an expected call of WatchNodes
+func (mr *MockOperatorMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperator)(nil).WatchNodes), ctx, query)
+}
+
+// GetNode mocks base method
+func (m *MockOperator) GetNode(ctx context.Context, name string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNode", ctx, name)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNode indicates an expected call of GetNode
+func (mr *MockOperatorMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperator)(nil).GetNode), ctx, name)
+}
+
+// GetNodeEx mocks base method
+func (m *MockOperator) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeEx indicates an expected call of GetNodeEx
+func (mr *MockOperatorMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperator)(nil).GetNodeEx), ctx, name, resourceVersion)
+}
+
+// ListNodesEx mocks base method
+func (m *MockOperator) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodesEx indicates an expected call of ListNodesEx
+func (mr *MockOperatorMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperator)(nil).ListNodesEx), ctx, query)
+}
+
+// UpdateNode mocks base method
+func (m *MockOperator) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNode indicates an expected call of UpdateNode
+func (mr *MockOperatorMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockOperator)(nil).UpdateNode), ctx, node)
+}
+
+// CreateNode mocks base method
+func (m *MockOperator) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNode indicates an expected call of CreateNode
+func (mr *MockOperatorMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperator)(nil).CreateNode), ctx, node)
+}
+
+// DeleteNode mocks base method
+func (m *MockOperator) DeleteNode(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNode indicates an expected call of DeleteNode
+func (mr *MockOperatorMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperator)(nil).DeleteNode), ctx, name)
+}
+
+// ListBackups mocks base method
+func (m *MockOperator) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackups indicates an expected call of ListBackups
+func (mr *MockOperatorMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperator)(nil).ListBackups), ctx, query)
+}
+
+// WatchBackups mocks base method
+func (m *MockOperator) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackups indicates an expected call of WatchBackups
+func (mr *MockOperatorMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperator)(nil).WatchBackups), ctx, query)
+}
+
+// GetBackup mocks base method
+func (m *MockOperator) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackup indicates an expected call of GetBackup
+func (mr *MockOperatorMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockOperator)(nil).GetBackup), ctx, cluster, name)
+}
+
+// ListBackupEx mocks base method
+func (m *MockOperator) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupEx indicates an expected call of ListBackupEx
+func (mr *MockOperatorMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperator)(nil).ListBackupEx), ctx, query)
+}
+
+// GetBackupEx mocks base method
+func (m *MockOperator) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupEx indicates an expected call of GetBackupEx
+func (mr *MockOperatorMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockOperator)(nil).GetBackupEx), ctx, cluster, name)
+}
+
+// CreateBackup mocks base method
+func (m *MockOperator) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateBackup indicates an expected call of CreateBackup
+func (mr *MockOperatorMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockOperator)(nil).CreateBackup), ctc, backup)
+}
+
+// UpdateBackup mocks base method
+func (m *MockOperator) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateBackup indicates an expected call of UpdateBackup
+func (mr *MockOperatorMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperator)(nil).UpdateBackup), ctx, backup)
+}
+
+// DeleteBackup mocks base method
+func (m *MockOperator) DeleteBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackup indicates an expected call of DeleteBackup
+func (mr *MockOperatorMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperator)(nil).DeleteBackup), ctx, name)
+}
+
+// ListBackupPoints mocks base method
+func (m *MockOperator) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupPointList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPoints indicates an expected call of ListBackupPoints
+func (mr *MockOperatorMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperator)(nil).ListBackupPoints), ctx, query)
+}
+
+// GetBackupPoint mocks base method
+func (m *MockOperator) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPoint indicates an expected call of GetBackupPoint
+func (mr *MockOperatorMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockOperator)(nil).GetBackupPoint), ctx, name, resourceVersion)
+}
+
+// WatchBackupPoints mocks base method
+func (m *MockOperator) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackupPoints indicates an expected call of WatchBackupPoints
+func (mr *MockOperatorMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockOperator)(nil).WatchBackupPoints), ctx, query)
+}
+
+// ListBackupPointEx mocks base method
+func (m *MockOperator) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPointEx indicates an expected call of ListBackupPointEx
+func (mr *MockOperatorMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperator)(nil).ListBackupPointEx), ctx, query)
+}
+
+// GetBackupPointEx mocks base method
+func (m *MockOperator) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPointEx indicates an expected call of GetBackupPointEx
+func (mr *MockOperatorMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockOperator)(nil).GetBackupPointEx), ctx, name, resourceVersion)
+}
+
+// CreateBackupPoint mocks base method
+func (m *MockOperator) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateBackupPoint indicates an expected call of CreateBackupPoint
+func (mr *MockOperatorMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockOperator)(nil).CreateBackupPoint), ctx, backupPoint)
+}
+
+// UpdateBackupPoint mocks base method
+func (m *MockOperator) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateBackupPoint indicates an expected call of UpdateBackupPoint
+func (mr *MockOperatorMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperator)(nil).UpdateBackupPoint), ctx, backupPoint)
+}
+
+// DeleteBackupPoint mocks base method
+func (m *MockOperator) DeleteBackupPoint(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackupPoint indicates an expected call of DeleteBackupPoint
+func (mr *MockOperatorMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperator)(nil).DeleteBackupPoint), ctx, name)
+}
+
+// ListCronBackups mocks base method
+func (m *MockOperator) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.CronBackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackups indicates an expected call of ListCronBackups
+func (mr *MockOperatorMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperator)(nil).ListCronBackups), ctx, query)
+}
+
+// GetCronBackup mocks base method
+func (m *MockOperator) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackup indicates an expected call of GetCronBackup
+func (mr *MockOperatorMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockOperator)(nil).GetCronBackup), ctx, name, resourceVersion)
+}
+
+// WatchCronBackups mocks base method
+func (m *MockOperator) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchCronBackups indicates an expected call of WatchCronBackups
+func (mr *MockOperatorMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockOperator)(nil).WatchCronBackups), ctx, query)
+}
+
+// ListCronBackupEx mocks base method
+func (m *MockOperator) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackupEx indicates an expected call of ListCronBackupEx
+func (mr *MockOperatorMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperator)(nil).ListCronBackupEx), ctx, query)
+}
+
+// GetCronBackupEx mocks base method
+func (m *MockOperator) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackupEx indicates an expected call of GetCronBackupEx
+func (mr *MockOperatorMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockOperator)(nil).GetCronBackupEx), ctx, name, resourceVersion)
+}
+
+// CreateCronBackup mocks base method
+func (m *MockOperator) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateCronBackup indicates an expected call of CreateCronBackup
+func (mr *MockOperatorMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockOperator)(nil).CreateCronBackup), ctx, cronBackup)
+}
+
+// UpdateCronBackup mocks base method
+func (m *MockOperator) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCronBackup indicates an expected call of UpdateCronBackup
+func (mr *MockOperatorMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperator)(nil).UpdateCronBackup), ctx, cronBackup)
+}
+
+// DeleteCronBackup mocks base method
+func (m *MockOperator) DeleteCronBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackup indicates an expected call of DeleteCronBackup
+func (mr *MockOperatorMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperator)(nil).DeleteCronBackup), ctx, name)
+}
+
+// ListDomains mocks base method
+func (m *MockOperator) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
+	ret0, _ := ret[0].(*v1.DomainList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomains indicates an expected call of ListDomains
+func (mr *MockOperatorMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperator)(nil).ListDomains), ctx, query)
+}
+
+// GetDomain mocks base method
+func (m *MockOperator) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
+	ret0, _ := ret[0].(*v1.Domain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDomain indicates an expected call of GetDomain
+func (mr *MockOperatorMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockOperator)(nil).GetDomain), ctx, name)
+}
+
+// WatchDomain mocks base method
+func (m *MockOperator) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchDomain indicates an expected call of WatchDomain
+func (mr *MockOperatorMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperator)(nil).WatchDomain), ctx, query)
+}
+
+// ListRecordsEx mocks base method
+func (m *MockOperator) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRecordsEx indicates an expected call of ListRecordsEx
+func (mr *MockOperatorMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperator)(nil).ListRecordsEx), ctx, name, subdomain, query)
+}
+
+// ListDomainsEx mocks base method
+func (m *MockOperator) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomainsEx indicates an expected call of ListDomainsEx
+func (mr *MockOperatorMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockOperator)(nil).ListDomainsEx), ctx, query)
+}
+
+// CreateDomain mocks base method
+func (m *MockOperator) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
+	ret0, _ := ret[0].(*v1.Domain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateDomain indicates an expected call of CreateDomain
+func (mr *MockOperatorMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockOperator)(nil).CreateDomain), ctc, domain)
+}
+
+// UpdateDomain mocks base method
+func (m *MockOperator) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
+	ret0, _ := ret[0].(*v1.Domain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateDomain indicates an expected call of UpdateDomain
+func (mr *MockOperatorMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockOperator)(nil).UpdateDomain), ctx, domain)
+}
+
+// DeleteDomain mocks base method
+func (m *MockOperator) DeleteDomain(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDomain indicates an expected call of DeleteDomain
+func (mr *MockOperatorMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperator)(nil).DeleteDomain), ctx, name)
+}
+
+// ListTemplates mocks base method
+func (m *MockOperator) ListTemplates(ctx context.Context, query *query.Query) (*v1.TemplateList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTemplates", ctx, query)
+	ret0, _ := ret[0].(*v1.TemplateList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTemplates indicates an expected call of ListTemplates
+func (mr *MockOperatorMockRecorder) ListTemplates(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplates", reflect.TypeOf((*MockOperator)(nil).ListTemplates), ctx, query)
+}
+
+// WatchTemplates mocks base method
 func (m *MockOperator) WatchTemplates(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchTemplates", ctx, query)
@@ -1787,81 +1743,139 @@ func (m *MockOperator) WatchTemplates(ctx context.Context, query *query.Query) (
 	return ret0, ret1
 }
 
-// WatchTemplates indicates an expected call of WatchTemplates.
+// WatchTemplates indicates an expected call of WatchTemplates
 func (mr *MockOperatorMockRecorder) WatchTemplates(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTemplates", reflect.TypeOf((*MockOperator)(nil).WatchTemplates), ctx, query)
 }
 
-// MockClusterReader is a mock of ClusterReader interface.
+// GetTemplate mocks base method
+func (m *MockOperator) GetTemplate(ctx context.Context, name string) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplate", ctx, name)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemplate indicates an expected call of GetTemplate
+func (mr *MockOperatorMockRecorder) GetTemplate(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockOperator)(nil).GetTemplate), ctx, name)
+}
+
+// ListTemplatesEx mocks base method
+func (m *MockOperator) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTemplatesEx indicates an expected call of ListTemplatesEx
+func (mr *MockOperatorMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockOperator)(nil).ListTemplatesEx), ctx, query)
+}
+
+// GetTemplateEx mocks base method
+func (m *MockOperator) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemplateEx indicates an expected call of GetTemplateEx
+func (mr *MockOperatorMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockOperator)(nil).GetTemplateEx), ctx, name, resourceVersion)
+}
+
+// CreateTemplate mocks base method
+func (m *MockOperator) CreateTemplate(ctc context.Context, template *v1.Template) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTemplate", ctc, template)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTemplate indicates an expected call of CreateTemplate
+func (mr *MockOperatorMockRecorder) CreateTemplate(ctc, template interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTemplate", reflect.TypeOf((*MockOperator)(nil).CreateTemplate), ctc, template)
+}
+
+// UpdateTemplate mocks base method
+func (m *MockOperator) UpdateTemplate(ctx context.Context, template *v1.Template) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateTemplate", ctx, template)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateTemplate indicates an expected call of UpdateTemplate
+func (mr *MockOperatorMockRecorder) UpdateTemplate(ctx, template interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplate", reflect.TypeOf((*MockOperator)(nil).UpdateTemplate), ctx, template)
+}
+
+// DeleteTemplate mocks base method
+func (m *MockOperator) DeleteTemplate(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplate indicates an expected call of DeleteTemplate
+func (mr *MockOperatorMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockOperator)(nil).DeleteTemplate), ctx, name)
+}
+
+// DeleteTemplateCollection mocks base method
+func (m *MockOperator) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection
+func (mr *MockOperatorMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockOperator)(nil).DeleteTemplateCollection), ctx, query)
+}
+
+// MockClusterReader is a mock of ClusterReader interface
 type MockClusterReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterReaderMockRecorder
 }
 
-// MockClusterReaderMockRecorder is the mock recorder for MockClusterReader.
+// MockClusterReaderMockRecorder is the mock recorder for MockClusterReader
 type MockClusterReaderMockRecorder struct {
 	mock *MockClusterReader
 }
 
-// NewMockClusterReader creates a new mock instance.
+// NewMockClusterReader creates a new mock instance
 func NewMockClusterReader(ctrl *gomock.Controller) *MockClusterReader {
 	mock := &MockClusterReader{ctrl: ctrl}
 	mock.recorder = &MockClusterReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClusterReader) EXPECT() *MockClusterReaderMockRecorder {
 	return m.recorder
 }
 
-// GetCluster mocks base method.
-func (m *MockClusterReader) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCluster indicates an expected call of GetCluster.
-func (mr *MockClusterReaderMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockClusterReader)(nil).GetCluster), ctx, name)
-}
-
-// GetClusterEx mocks base method.
-func (m *MockClusterReader) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterEx indicates an expected call of GetClusterEx.
-func (mr *MockClusterReaderMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockClusterReader)(nil).GetClusterEx), ctx, name, resourceVersion)
-}
-
-// ListClusterEx mocks base method.
-func (m *MockClusterReader) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusterEx indicates an expected call of ListClusterEx.
-func (mr *MockClusterReaderMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockClusterReader)(nil).ListClusterEx), ctx, query)
-}
-
-// ListClusters mocks base method.
+// ListClusters mocks base method
 func (m *MockClusterReader) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
@@ -1870,13 +1884,13 @@ func (m *MockClusterReader) ListClusters(ctx context.Context, query *query.Query
 	return ret0, ret1
 }
 
-// ListClusters indicates an expected call of ListClusters.
+// ListClusters indicates an expected call of ListClusters
 func (mr *MockClusterReaderMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockClusterReader)(nil).ListClusters), ctx, query)
 }
 
-// WatchClusters mocks base method.
+// WatchClusters mocks base method
 func (m *MockClusterReader) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
@@ -1885,36 +1899,81 @@ func (m *MockClusterReader) WatchClusters(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// WatchClusters indicates an expected call of WatchClusters.
+// WatchClusters indicates an expected call of WatchClusters
 func (mr *MockClusterReaderMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockClusterReader)(nil).WatchClusters), ctx, query)
 }
 
-// MockClusterReaderEx is a mock of ClusterReaderEx interface.
+// GetCluster mocks base method
+func (m *MockClusterReader) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCluster indicates an expected call of GetCluster
+func (mr *MockClusterReaderMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockClusterReader)(nil).GetCluster), ctx, name)
+}
+
+// GetClusterEx mocks base method
+func (m *MockClusterReader) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterEx indicates an expected call of GetClusterEx
+func (mr *MockClusterReaderMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockClusterReader)(nil).GetClusterEx), ctx, name, resourceVersion)
+}
+
+// ListClusterEx mocks base method
+func (m *MockClusterReader) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusterEx indicates an expected call of ListClusterEx
+func (mr *MockClusterReaderMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockClusterReader)(nil).ListClusterEx), ctx, query)
+}
+
+// MockClusterReaderEx is a mock of ClusterReaderEx interface
 type MockClusterReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterReaderExMockRecorder
 }
 
-// MockClusterReaderExMockRecorder is the mock recorder for MockClusterReaderEx.
+// MockClusterReaderExMockRecorder is the mock recorder for MockClusterReaderEx
 type MockClusterReaderExMockRecorder struct {
 	mock *MockClusterReaderEx
 }
 
-// NewMockClusterReaderEx creates a new mock instance.
+// NewMockClusterReaderEx creates a new mock instance
 func NewMockClusterReaderEx(ctrl *gomock.Controller) *MockClusterReaderEx {
 	mock := &MockClusterReaderEx{ctrl: ctrl}
 	mock.recorder = &MockClusterReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClusterReaderEx) EXPECT() *MockClusterReaderExMockRecorder {
 	return m.recorder
 }
 
-// GetClusterEx mocks base method.
+// GetClusterEx mocks base method
 func (m *MockClusterReaderEx) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
@@ -1923,13 +1982,13 @@ func (m *MockClusterReaderEx) GetClusterEx(ctx context.Context, name, resourceVe
 	return ret0, ret1
 }
 
-// GetClusterEx indicates an expected call of GetClusterEx.
+// GetClusterEx indicates an expected call of GetClusterEx
 func (mr *MockClusterReaderExMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockClusterReaderEx)(nil).GetClusterEx), ctx, name, resourceVersion)
 }
 
-// ListClusterEx mocks base method.
+// ListClusterEx mocks base method
 func (m *MockClusterReaderEx) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
@@ -1938,36 +1997,36 @@ func (m *MockClusterReaderEx) ListClusterEx(ctx context.Context, query *query.Qu
 	return ret0, ret1
 }
 
-// ListClusterEx indicates an expected call of ListClusterEx.
+// ListClusterEx indicates an expected call of ListClusterEx
 func (mr *MockClusterReaderExMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockClusterReaderEx)(nil).ListClusterEx), ctx, query)
 }
 
-// MockClusterWriter is a mock of ClusterWriter interface.
+// MockClusterWriter is a mock of ClusterWriter interface
 type MockClusterWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterWriterMockRecorder
 }
 
-// MockClusterWriterMockRecorder is the mock recorder for MockClusterWriter.
+// MockClusterWriterMockRecorder is the mock recorder for MockClusterWriter
 type MockClusterWriterMockRecorder struct {
 	mock *MockClusterWriter
 }
 
-// NewMockClusterWriter creates a new mock instance.
+// NewMockClusterWriter creates a new mock instance
 func NewMockClusterWriter(ctrl *gomock.Controller) *MockClusterWriter {
 	mock := &MockClusterWriter{ctrl: ctrl}
 	mock.recorder = &MockClusterWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClusterWriter) EXPECT() *MockClusterWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateCluster mocks base method.
+// CreateCluster mocks base method
 func (m *MockClusterWriter) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
@@ -1976,27 +2035,13 @@ func (m *MockClusterWriter) CreateCluster(ctx context.Context, cluster *v1.Clust
 	return ret0, ret1
 }
 
-// CreateCluster indicates an expected call of CreateCluster.
+// CreateCluster indicates an expected call of CreateCluster
 func (mr *MockClusterWriterMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockClusterWriter)(nil).CreateCluster), ctx, cluster)
 }
 
-// DeleteCluster mocks base method.
-func (m *MockClusterWriter) DeleteCluster(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCluster indicates an expected call of DeleteCluster.
-func (mr *MockClusterWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterWriter)(nil).DeleteCluster), ctx, name)
-}
-
-// UpdateCluster mocks base method.
+// UpdateCluster mocks base method
 func (m *MockClusterWriter) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
@@ -2005,81 +2050,50 @@ func (m *MockClusterWriter) UpdateCluster(ctx context.Context, cluster *v1.Clust
 	return ret0, ret1
 }
 
-// UpdateCluster indicates an expected call of UpdateCluster.
+// UpdateCluster indicates an expected call of UpdateCluster
 func (mr *MockClusterWriterMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockClusterWriter)(nil).UpdateCluster), ctx, cluster)
 }
 
-// MockRegionReader is a mock of RegionReader interface.
+// DeleteCluster mocks base method
+func (m *MockClusterWriter) DeleteCluster(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCluster indicates an expected call of DeleteCluster
+func (mr *MockClusterWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterWriter)(nil).DeleteCluster), ctx, name)
+}
+
+// MockRegionReader is a mock of RegionReader interface
 type MockRegionReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockRegionReaderMockRecorder
 }
 
-// MockRegionReaderMockRecorder is the mock recorder for MockRegionReader.
+// MockRegionReaderMockRecorder is the mock recorder for MockRegionReader
 type MockRegionReaderMockRecorder struct {
 	mock *MockRegionReader
 }
 
-// NewMockRegionReader creates a new mock instance.
+// NewMockRegionReader creates a new mock instance
 func NewMockRegionReader(ctrl *gomock.Controller) *MockRegionReader {
 	mock := &MockRegionReader{ctrl: ctrl}
 	mock.recorder = &MockRegionReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockRegionReader) EXPECT() *MockRegionReaderMockRecorder {
 	return m.recorder
 }
 
-// GetRegion mocks base method.
-func (m *MockRegionReader) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegion indicates an expected call of GetRegion.
-func (mr *MockRegionReaderMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockRegionReader)(nil).GetRegion), ctx, name)
-}
-
-// GetRegionEx mocks base method.
-func (m *MockRegionReader) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegionEx indicates an expected call of GetRegionEx.
-func (mr *MockRegionReaderMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockRegionReader)(nil).GetRegionEx), ctx, name, resourceVersion)
-}
-
-// ListRegionEx mocks base method.
-func (m *MockRegionReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegionEx indicates an expected call of ListRegionEx.
-func (mr *MockRegionReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockRegionReader)(nil).ListRegionEx), ctx, query)
-}
-
-// ListRegions mocks base method.
+// ListRegions mocks base method
 func (m *MockRegionReader) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
@@ -2088,13 +2102,28 @@ func (m *MockRegionReader) ListRegions(ctx context.Context, query *query.Query) 
 	return ret0, ret1
 }
 
-// ListRegions indicates an expected call of ListRegions.
+// ListRegions indicates an expected call of ListRegions
 func (mr *MockRegionReaderMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockRegionReader)(nil).ListRegions), ctx, query)
 }
 
-// WatchRegions mocks base method.
+// GetRegion mocks base method
+func (m *MockRegionReader) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegion indicates an expected call of GetRegion
+func (mr *MockRegionReaderMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockRegionReader)(nil).GetRegion), ctx, name)
+}
+
+// WatchRegions mocks base method
 func (m *MockRegionReader) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
@@ -2103,37 +2132,29 @@ func (m *MockRegionReader) WatchRegions(ctx context.Context, query *query.Query)
 	return ret0, ret1
 }
 
-// WatchRegions indicates an expected call of WatchRegions.
+// WatchRegions indicates an expected call of WatchRegions
 func (mr *MockRegionReaderMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockRegionReader)(nil).WatchRegions), ctx, query)
 }
 
-// MockRegionReaderEx is a mock of RegionReaderEx interface.
-type MockRegionReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockRegionReaderExMockRecorder
+// ListRegionEx mocks base method
+func (m *MockRegionReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// MockRegionReaderExMockRecorder is the mock recorder for MockRegionReaderEx.
-type MockRegionReaderExMockRecorder struct {
-	mock *MockRegionReaderEx
+// ListRegionEx indicates an expected call of ListRegionEx
+func (mr *MockRegionReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockRegionReader)(nil).ListRegionEx), ctx, query)
 }
 
-// NewMockRegionReaderEx creates a new mock instance.
-func NewMockRegionReaderEx(ctrl *gomock.Controller) *MockRegionReaderEx {
-	mock := &MockRegionReaderEx{ctrl: ctrl}
-	mock.recorder = &MockRegionReaderExMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRegionReaderEx) EXPECT() *MockRegionReaderExMockRecorder {
-	return m.recorder
-}
-
-// GetRegionEx mocks base method.
-func (m *MockRegionReaderEx) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
+// GetRegionEx mocks base method
+func (m *MockRegionReader) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
 	ret0, _ := ret[0].(*v1.Region)
@@ -2141,13 +2162,36 @@ func (m *MockRegionReaderEx) GetRegionEx(ctx context.Context, name, resourceVers
 	return ret0, ret1
 }
 
-// GetRegionEx indicates an expected call of GetRegionEx.
-func (mr *MockRegionReaderExMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+// GetRegionEx indicates an expected call of GetRegionEx
+func (mr *MockRegionReaderMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockRegionReaderEx)(nil).GetRegionEx), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockRegionReader)(nil).GetRegionEx), ctx, name, resourceVersion)
 }
 
-// ListRegionEx mocks base method.
+// MockRegionReaderEx is a mock of RegionReaderEx interface
+type MockRegionReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockRegionReaderExMockRecorder
+}
+
+// MockRegionReaderExMockRecorder is the mock recorder for MockRegionReaderEx
+type MockRegionReaderExMockRecorder struct {
+	mock *MockRegionReaderEx
+}
+
+// NewMockRegionReaderEx creates a new mock instance
+func NewMockRegionReaderEx(ctrl *gomock.Controller) *MockRegionReaderEx {
+	mock := &MockRegionReaderEx{ctrl: ctrl}
+	mock.recorder = &MockRegionReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockRegionReaderEx) EXPECT() *MockRegionReaderExMockRecorder {
+	return m.recorder
+}
+
+// ListRegionEx mocks base method
 func (m *MockRegionReaderEx) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
@@ -2156,36 +2200,51 @@ func (m *MockRegionReaderEx) ListRegionEx(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// ListRegionEx indicates an expected call of ListRegionEx.
+// ListRegionEx indicates an expected call of ListRegionEx
 func (mr *MockRegionReaderExMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockRegionReaderEx)(nil).ListRegionEx), ctx, query)
 }
 
-// MockRegionWriter is a mock of RegionWriter interface.
+// GetRegionEx mocks base method
+func (m *MockRegionReaderEx) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegionEx indicates an expected call of GetRegionEx
+func (mr *MockRegionReaderExMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockRegionReaderEx)(nil).GetRegionEx), ctx, name, resourceVersion)
+}
+
+// MockRegionWriter is a mock of RegionWriter interface
 type MockRegionWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockRegionWriterMockRecorder
 }
 
-// MockRegionWriterMockRecorder is the mock recorder for MockRegionWriter.
+// MockRegionWriterMockRecorder is the mock recorder for MockRegionWriter
 type MockRegionWriterMockRecorder struct {
 	mock *MockRegionWriter
 }
 
-// NewMockRegionWriter creates a new mock instance.
+// NewMockRegionWriter creates a new mock instance
 func NewMockRegionWriter(ctrl *gomock.Controller) *MockRegionWriter {
 	mock := &MockRegionWriter{ctrl: ctrl}
 	mock.recorder = &MockRegionWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockRegionWriter) EXPECT() *MockRegionWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateRegion mocks base method.
+// CreateRegion mocks base method
 func (m *MockRegionWriter) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
@@ -2194,13 +2253,13 @@ func (m *MockRegionWriter) CreateRegion(ctx context.Context, region *v1.Region) 
 	return ret0, ret1
 }
 
-// CreateRegion indicates an expected call of CreateRegion.
+// CreateRegion indicates an expected call of CreateRegion
 func (mr *MockRegionWriterMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockRegionWriter)(nil).CreateRegion), ctx, region)
 }
 
-// DeleteRegion mocks base method.
+// DeleteRegion mocks base method
 func (m *MockRegionWriter) DeleteRegion(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
@@ -2208,66 +2267,36 @@ func (m *MockRegionWriter) DeleteRegion(ctx context.Context, name string) error 
 	return ret0
 }
 
-// DeleteRegion indicates an expected call of DeleteRegion.
+// DeleteRegion indicates an expected call of DeleteRegion
 func (mr *MockRegionWriterMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockRegionWriter)(nil).DeleteRegion), ctx, name)
 }
 
-// MockNodeReader is a mock of NodeReader interface.
+// MockNodeReader is a mock of NodeReader interface
 type MockNodeReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeReaderMockRecorder
 }
 
-// MockNodeReaderMockRecorder is the mock recorder for MockNodeReader.
+// MockNodeReaderMockRecorder is the mock recorder for MockNodeReader
 type MockNodeReaderMockRecorder struct {
 	mock *MockNodeReader
 }
 
-// NewMockNodeReader creates a new mock instance.
+// NewMockNodeReader creates a new mock instance
 func NewMockNodeReader(ctrl *gomock.Controller) *MockNodeReader {
 	mock := &MockNodeReader{ctrl: ctrl}
 	mock.recorder = &MockNodeReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockNodeReader) EXPECT() *MockNodeReaderMockRecorder {
 	return m.recorder
 }
 
-// GetNode mocks base method.
-func (m *MockNodeReader) GetNode(ctx context.Context, name string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNode", ctx, name)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNode indicates an expected call of GetNode.
-func (mr *MockNodeReaderMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockNodeReader)(nil).GetNode), ctx, name)
-}
-
-// GetNodeEx mocks base method.
-func (m *MockNodeReader) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNodeEx indicates an expected call of GetNodeEx.
-func (mr *MockNodeReaderMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockNodeReader)(nil).GetNodeEx), ctx, name, resourceVersion)
-}
-
-// ListNodes mocks base method.
+// ListNodes mocks base method
 func (m *MockNodeReader) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
@@ -2276,28 +2305,13 @@ func (m *MockNodeReader) ListNodes(ctx context.Context, query *query.Query) (*v1
 	return ret0, ret1
 }
 
-// ListNodes indicates an expected call of ListNodes.
+// ListNodes indicates an expected call of ListNodes
 func (mr *MockNodeReaderMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockNodeReader)(nil).ListNodes), ctx, query)
 }
 
-// ListNodesEx mocks base method.
-func (m *MockNodeReader) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodesEx indicates an expected call of ListNodesEx.
-func (mr *MockNodeReaderMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockNodeReader)(nil).ListNodesEx), ctx, query)
-}
-
-// WatchNodes mocks base method.
+// WatchNodes mocks base method
 func (m *MockNodeReader) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
@@ -2306,36 +2320,81 @@ func (m *MockNodeReader) WatchNodes(ctx context.Context, query *query.Query) (wa
 	return ret0, ret1
 }
 
-// WatchNodes indicates an expected call of WatchNodes.
+// WatchNodes indicates an expected call of WatchNodes
 func (mr *MockNodeReaderMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockNodeReader)(nil).WatchNodes), ctx, query)
 }
 
-// MockNodeReaderEx is a mock of NodeReaderEx interface.
+// GetNode mocks base method
+func (m *MockNodeReader) GetNode(ctx context.Context, name string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNode", ctx, name)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNode indicates an expected call of GetNode
+func (mr *MockNodeReaderMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockNodeReader)(nil).GetNode), ctx, name)
+}
+
+// GetNodeEx mocks base method
+func (m *MockNodeReader) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeEx indicates an expected call of GetNodeEx
+func (mr *MockNodeReaderMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockNodeReader)(nil).GetNodeEx), ctx, name, resourceVersion)
+}
+
+// ListNodesEx mocks base method
+func (m *MockNodeReader) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodesEx indicates an expected call of ListNodesEx
+func (mr *MockNodeReaderMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockNodeReader)(nil).ListNodesEx), ctx, query)
+}
+
+// MockNodeReaderEx is a mock of NodeReaderEx interface
 type MockNodeReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeReaderExMockRecorder
 }
 
-// MockNodeReaderExMockRecorder is the mock recorder for MockNodeReaderEx.
+// MockNodeReaderExMockRecorder is the mock recorder for MockNodeReaderEx
 type MockNodeReaderExMockRecorder struct {
 	mock *MockNodeReaderEx
 }
 
-// NewMockNodeReaderEx creates a new mock instance.
+// NewMockNodeReaderEx creates a new mock instance
 func NewMockNodeReaderEx(ctrl *gomock.Controller) *MockNodeReaderEx {
 	mock := &MockNodeReaderEx{ctrl: ctrl}
 	mock.recorder = &MockNodeReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockNodeReaderEx) EXPECT() *MockNodeReaderExMockRecorder {
 	return m.recorder
 }
 
-// GetNodeEx mocks base method.
+// GetNodeEx mocks base method
 func (m *MockNodeReaderEx) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
@@ -2344,13 +2403,13 @@ func (m *MockNodeReaderEx) GetNodeEx(ctx context.Context, name, resourceVersion 
 	return ret0, ret1
 }
 
-// GetNodeEx indicates an expected call of GetNodeEx.
+// GetNodeEx indicates an expected call of GetNodeEx
 func (mr *MockNodeReaderExMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockNodeReaderEx)(nil).GetNodeEx), ctx, name, resourceVersion)
 }
 
-// ListNodesEx mocks base method.
+// ListNodesEx mocks base method
 func (m *MockNodeReaderEx) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
@@ -2359,65 +2418,36 @@ func (m *MockNodeReaderEx) ListNodesEx(ctx context.Context, query *query.Query) 
 	return ret0, ret1
 }
 
-// ListNodesEx indicates an expected call of ListNodesEx.
+// ListNodesEx indicates an expected call of ListNodesEx
 func (mr *MockNodeReaderExMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockNodeReaderEx)(nil).ListNodesEx), ctx, query)
 }
 
-// MockNodeWriter is a mock of NodeWriter interface.
+// MockNodeWriter is a mock of NodeWriter interface
 type MockNodeWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeWriterMockRecorder
 }
 
-// MockNodeWriterMockRecorder is the mock recorder for MockNodeWriter.
+// MockNodeWriterMockRecorder is the mock recorder for MockNodeWriter
 type MockNodeWriterMockRecorder struct {
 	mock *MockNodeWriter
 }
 
-// NewMockNodeWriter creates a new mock instance.
+// NewMockNodeWriter creates a new mock instance
 func NewMockNodeWriter(ctrl *gomock.Controller) *MockNodeWriter {
 	mock := &MockNodeWriter{ctrl: ctrl}
 	mock.recorder = &MockNodeWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockNodeWriter) EXPECT() *MockNodeWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateNode mocks base method.
-func (m *MockNodeWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateNode indicates an expected call of CreateNode.
-func (mr *MockNodeWriterMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockNodeWriter)(nil).CreateNode), ctx, node)
-}
-
-// DeleteNode mocks base method.
-func (m *MockNodeWriter) DeleteNode(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteNode indicates an expected call of DeleteNode.
-func (mr *MockNodeWriterMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockNodeWriter)(nil).DeleteNode), ctx, name)
-}
-
-// UpdateNode mocks base method.
+// UpdateNode mocks base method
 func (m *MockNodeWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
@@ -2426,81 +2456,65 @@ func (m *MockNodeWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Nod
 	return ret0, ret1
 }
 
-// UpdateNode indicates an expected call of UpdateNode.
+// UpdateNode indicates an expected call of UpdateNode
 func (mr *MockNodeWriterMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockNodeWriter)(nil).UpdateNode), ctx, node)
 }
 
-// MockBackupReader is a mock of BackupReader interface.
+// CreateNode mocks base method
+func (m *MockNodeWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNode indicates an expected call of CreateNode
+func (mr *MockNodeWriterMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockNodeWriter)(nil).CreateNode), ctx, node)
+}
+
+// DeleteNode mocks base method
+func (m *MockNodeWriter) DeleteNode(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNode indicates an expected call of DeleteNode
+func (mr *MockNodeWriterMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockNodeWriter)(nil).DeleteNode), ctx, name)
+}
+
+// MockBackupReader is a mock of BackupReader interface
 type MockBackupReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupReaderMockRecorder
 }
 
-// MockBackupReaderMockRecorder is the mock recorder for MockBackupReader.
+// MockBackupReaderMockRecorder is the mock recorder for MockBackupReader
 type MockBackupReaderMockRecorder struct {
 	mock *MockBackupReader
 }
 
-// NewMockBackupReader creates a new mock instance.
+// NewMockBackupReader creates a new mock instance
 func NewMockBackupReader(ctrl *gomock.Controller) *MockBackupReader {
 	mock := &MockBackupReader{ctrl: ctrl}
 	mock.recorder = &MockBackupReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockBackupReader) EXPECT() *MockBackupReaderMockRecorder {
 	return m.recorder
 }
 
-// GetBackup mocks base method.
-func (m *MockBackupReader) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackup indicates an expected call of GetBackup.
-func (mr *MockBackupReaderMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockBackupReader)(nil).GetBackup), ctx, cluster, name)
-}
-
-// GetBackupEx mocks base method.
-func (m *MockBackupReader) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupEx indicates an expected call of GetBackupEx.
-func (mr *MockBackupReaderMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockBackupReader)(nil).GetBackupEx), ctx, cluster, name)
-}
-
-// ListBackupEx mocks base method.
-func (m *MockBackupReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupEx indicates an expected call of ListBackupEx.
-func (mr *MockBackupReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockBackupReader)(nil).ListBackupEx), ctx, query)
-}
-
-// ListBackups mocks base method.
+// ListBackups mocks base method
 func (m *MockBackupReader) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
@@ -2509,13 +2523,13 @@ func (m *MockBackupReader) ListBackups(ctx context.Context, query *query.Query) 
 	return ret0, ret1
 }
 
-// ListBackups indicates an expected call of ListBackups.
+// ListBackups indicates an expected call of ListBackups
 func (mr *MockBackupReaderMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockBackupReader)(nil).ListBackups), ctx, query)
 }
 
-// WatchBackups mocks base method.
+// WatchBackups mocks base method
 func (m *MockBackupReader) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
@@ -2524,37 +2538,44 @@ func (m *MockBackupReader) WatchBackups(ctx context.Context, query *query.Query)
 	return ret0, ret1
 }
 
-// WatchBackups indicates an expected call of WatchBackups.
+// WatchBackups indicates an expected call of WatchBackups
 func (mr *MockBackupReaderMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockBackupReader)(nil).WatchBackups), ctx, query)
 }
 
-// MockBackupReaderEx is a mock of BackupReaderEx interface.
-type MockBackupReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockBackupReaderExMockRecorder
+// GetBackup mocks base method
+func (m *MockBackupReader) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// MockBackupReaderExMockRecorder is the mock recorder for MockBackupReaderEx.
-type MockBackupReaderExMockRecorder struct {
-	mock *MockBackupReaderEx
+// GetBackup indicates an expected call of GetBackup
+func (mr *MockBackupReaderMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockBackupReader)(nil).GetBackup), ctx, cluster, name)
 }
 
-// NewMockBackupReaderEx creates a new mock instance.
-func NewMockBackupReaderEx(ctrl *gomock.Controller) *MockBackupReaderEx {
-	mock := &MockBackupReaderEx{ctrl: ctrl}
-	mock.recorder = &MockBackupReaderExMockRecorder{mock}
-	return mock
+// ListBackupEx mocks base method
+func (m *MockBackupReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockBackupReaderEx) EXPECT() *MockBackupReaderExMockRecorder {
-	return m.recorder
+// ListBackupEx indicates an expected call of ListBackupEx
+func (mr *MockBackupReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockBackupReader)(nil).ListBackupEx), ctx, query)
 }
 
-// GetBackupEx mocks base method.
-func (m *MockBackupReaderEx) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+// GetBackupEx mocks base method
+func (m *MockBackupReader) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
 	ret0, _ := ret[0].(*v1.Backup)
@@ -2562,13 +2583,36 @@ func (m *MockBackupReaderEx) GetBackupEx(ctx context.Context, cluster, name stri
 	return ret0, ret1
 }
 
-// GetBackupEx indicates an expected call of GetBackupEx.
-func (mr *MockBackupReaderExMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
+// GetBackupEx indicates an expected call of GetBackupEx
+func (mr *MockBackupReaderMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockBackupReaderEx)(nil).GetBackupEx), ctx, cluster, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockBackupReader)(nil).GetBackupEx), ctx, cluster, name)
 }
 
-// ListBackupEx mocks base method.
+// MockBackupReaderEx is a mock of BackupReaderEx interface
+type MockBackupReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockBackupReaderExMockRecorder
+}
+
+// MockBackupReaderExMockRecorder is the mock recorder for MockBackupReaderEx
+type MockBackupReaderExMockRecorder struct {
+	mock *MockBackupReaderEx
+}
+
+// NewMockBackupReaderEx creates a new mock instance
+func NewMockBackupReaderEx(ctrl *gomock.Controller) *MockBackupReaderEx {
+	mock := &MockBackupReaderEx{ctrl: ctrl}
+	mock.recorder = &MockBackupReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockBackupReaderEx) EXPECT() *MockBackupReaderExMockRecorder {
+	return m.recorder
+}
+
+// ListBackupEx mocks base method
 func (m *MockBackupReaderEx) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
@@ -2577,36 +2621,51 @@ func (m *MockBackupReaderEx) ListBackupEx(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// ListBackupEx indicates an expected call of ListBackupEx.
+// ListBackupEx indicates an expected call of ListBackupEx
 func (mr *MockBackupReaderExMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockBackupReaderEx)(nil).ListBackupEx), ctx, query)
 }
 
-// MockBackupWriter is a mock of BackupWriter interface.
+// GetBackupEx mocks base method
+func (m *MockBackupReaderEx) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupEx indicates an expected call of GetBackupEx
+func (mr *MockBackupReaderExMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockBackupReaderEx)(nil).GetBackupEx), ctx, cluster, name)
+}
+
+// MockBackupWriter is a mock of BackupWriter interface
 type MockBackupWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupWriterMockRecorder
 }
 
-// MockBackupWriterMockRecorder is the mock recorder for MockBackupWriter.
+// MockBackupWriterMockRecorder is the mock recorder for MockBackupWriter
 type MockBackupWriterMockRecorder struct {
 	mock *MockBackupWriter
 }
 
-// NewMockBackupWriter creates a new mock instance.
+// NewMockBackupWriter creates a new mock instance
 func NewMockBackupWriter(ctrl *gomock.Controller) *MockBackupWriter {
 	mock := &MockBackupWriter{ctrl: ctrl}
 	mock.recorder = &MockBackupWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockBackupWriter) EXPECT() *MockBackupWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateBackup mocks base method.
+// CreateBackup mocks base method
 func (m *MockBackupWriter) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
@@ -2615,27 +2674,13 @@ func (m *MockBackupWriter) CreateBackup(ctc context.Context, backup *v1.Backup) 
 	return ret0, ret1
 }
 
-// CreateBackup indicates an expected call of CreateBackup.
+// CreateBackup indicates an expected call of CreateBackup
 func (mr *MockBackupWriterMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockBackupWriter)(nil).CreateBackup), ctc, backup)
 }
 
-// DeleteBackup mocks base method.
-func (m *MockBackupWriter) DeleteBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackup indicates an expected call of DeleteBackup.
-func (mr *MockBackupWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockBackupWriter)(nil).DeleteBackup), ctx, name)
-}
-
-// UpdateBackup mocks base method.
+// UpdateBackup mocks base method
 func (m *MockBackupWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
@@ -2644,66 +2689,50 @@ func (m *MockBackupWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) 
 	return ret0, ret1
 }
 
-// UpdateBackup indicates an expected call of UpdateBackup.
+// UpdateBackup indicates an expected call of UpdateBackup
 func (mr *MockBackupWriterMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockBackupWriter)(nil).UpdateBackup), ctx, backup)
 }
 
-// MockRecoveryReader is a mock of RecoveryReader interface.
+// DeleteBackup mocks base method
+func (m *MockBackupWriter) DeleteBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackup indicates an expected call of DeleteBackup
+func (mr *MockBackupWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockBackupWriter)(nil).DeleteBackup), ctx, name)
+}
+
+// MockRecoveryReader is a mock of RecoveryReader interface
 type MockRecoveryReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockRecoveryReaderMockRecorder
 }
 
-// MockRecoveryReaderMockRecorder is the mock recorder for MockRecoveryReader.
+// MockRecoveryReaderMockRecorder is the mock recorder for MockRecoveryReader
 type MockRecoveryReaderMockRecorder struct {
 	mock *MockRecoveryReader
 }
 
-// NewMockRecoveryReader creates a new mock instance.
+// NewMockRecoveryReader creates a new mock instance
 func NewMockRecoveryReader(ctrl *gomock.Controller) *MockRecoveryReader {
 	mock := &MockRecoveryReader{ctrl: ctrl}
 	mock.recorder = &MockRecoveryReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockRecoveryReader) EXPECT() *MockRecoveryReaderMockRecorder {
 	return m.recorder
 }
 
-// GetRecovery mocks base method.
-func (m *MockRecoveryReader) GetRecovery(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRecovery", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Recovery)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRecovery indicates an expected call of GetRecovery.
-func (mr *MockRecoveryReaderMockRecorder) GetRecovery(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecovery", reflect.TypeOf((*MockRecoveryReader)(nil).GetRecovery), ctx, cluster, name)
-}
-
-// GetRecoveryEx mocks base method.
-func (m *MockRecoveryReader) GetRecoveryEx(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRecoveryEx", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Recovery)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRecoveryEx indicates an expected call of GetRecoveryEx.
-func (mr *MockRecoveryReaderMockRecorder) GetRecoveryEx(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecoveryEx", reflect.TypeOf((*MockRecoveryReader)(nil).GetRecoveryEx), ctx, cluster, name)
-}
-
-// ListRecoveries mocks base method.
+// ListRecoveries mocks base method
 func (m *MockRecoveryReader) ListRecoveries(ctx context.Context, query *query.Query) (*v1.RecoveryList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRecoveries", ctx, query)
@@ -2712,28 +2741,13 @@ func (m *MockRecoveryReader) ListRecoveries(ctx context.Context, query *query.Qu
 	return ret0, ret1
 }
 
-// ListRecoveries indicates an expected call of ListRecoveries.
+// ListRecoveries indicates an expected call of ListRecoveries
 func (mr *MockRecoveryReaderMockRecorder) ListRecoveries(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveries", reflect.TypeOf((*MockRecoveryReader)(nil).ListRecoveries), ctx, query)
 }
 
-// ListRecoveryEx mocks base method.
-func (m *MockRecoveryReader) ListRecoveryEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecoveryEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecoveryEx indicates an expected call of ListRecoveryEx.
-func (mr *MockRecoveryReaderMockRecorder) ListRecoveryEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveryEx", reflect.TypeOf((*MockRecoveryReader)(nil).ListRecoveryEx), ctx, query)
-}
-
-// WatchRecoveries mocks base method.
+// WatchRecoveries mocks base method
 func (m *MockRecoveryReader) WatchRecoveries(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchRecoveries", ctx, query)
@@ -2742,37 +2756,44 @@ func (m *MockRecoveryReader) WatchRecoveries(ctx context.Context, query *query.Q
 	return ret0, ret1
 }
 
-// WatchRecoveries indicates an expected call of WatchRecoveries.
+// WatchRecoveries indicates an expected call of WatchRecoveries
 func (mr *MockRecoveryReaderMockRecorder) WatchRecoveries(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRecoveries", reflect.TypeOf((*MockRecoveryReader)(nil).WatchRecoveries), ctx, query)
 }
 
-// MockRecoveryReaderEx is a mock of RecoveryReaderEx interface.
-type MockRecoveryReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockRecoveryReaderExMockRecorder
+// GetRecovery mocks base method
+func (m *MockRecoveryReader) GetRecovery(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecovery", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Recovery)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// MockRecoveryReaderExMockRecorder is the mock recorder for MockRecoveryReaderEx.
-type MockRecoveryReaderExMockRecorder struct {
-	mock *MockRecoveryReaderEx
+// GetRecovery indicates an expected call of GetRecovery
+func (mr *MockRecoveryReaderMockRecorder) GetRecovery(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecovery", reflect.TypeOf((*MockRecoveryReader)(nil).GetRecovery), ctx, cluster, name)
 }
 
-// NewMockRecoveryReaderEx creates a new mock instance.
-func NewMockRecoveryReaderEx(ctrl *gomock.Controller) *MockRecoveryReaderEx {
-	mock := &MockRecoveryReaderEx{ctrl: ctrl}
-	mock.recorder = &MockRecoveryReaderExMockRecorder{mock}
-	return mock
+// ListRecoveryEx mocks base method
+func (m *MockRecoveryReader) ListRecoveryEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecoveryEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRecoveryReaderEx) EXPECT() *MockRecoveryReaderExMockRecorder {
-	return m.recorder
+// ListRecoveryEx indicates an expected call of ListRecoveryEx
+func (mr *MockRecoveryReaderMockRecorder) ListRecoveryEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveryEx", reflect.TypeOf((*MockRecoveryReader)(nil).ListRecoveryEx), ctx, query)
 }
 
-// GetRecoveryEx mocks base method.
-func (m *MockRecoveryReaderEx) GetRecoveryEx(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
+// GetRecoveryEx mocks base method
+func (m *MockRecoveryReader) GetRecoveryEx(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecoveryEx", ctx, cluster, name)
 	ret0, _ := ret[0].(*v1.Recovery)
@@ -2780,13 +2801,36 @@ func (m *MockRecoveryReaderEx) GetRecoveryEx(ctx context.Context, cluster, name 
 	return ret0, ret1
 }
 
-// GetRecoveryEx indicates an expected call of GetRecoveryEx.
-func (mr *MockRecoveryReaderExMockRecorder) GetRecoveryEx(ctx, cluster, name interface{}) *gomock.Call {
+// GetRecoveryEx indicates an expected call of GetRecoveryEx
+func (mr *MockRecoveryReaderMockRecorder) GetRecoveryEx(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecoveryEx", reflect.TypeOf((*MockRecoveryReaderEx)(nil).GetRecoveryEx), ctx, cluster, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecoveryEx", reflect.TypeOf((*MockRecoveryReader)(nil).GetRecoveryEx), ctx, cluster, name)
 }
 
-// ListRecoveryEx mocks base method.
+// MockRecoveryReaderEx is a mock of RecoveryReaderEx interface
+type MockRecoveryReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockRecoveryReaderExMockRecorder
+}
+
+// MockRecoveryReaderExMockRecorder is the mock recorder for MockRecoveryReaderEx
+type MockRecoveryReaderExMockRecorder struct {
+	mock *MockRecoveryReaderEx
+}
+
+// NewMockRecoveryReaderEx creates a new mock instance
+func NewMockRecoveryReaderEx(ctrl *gomock.Controller) *MockRecoveryReaderEx {
+	mock := &MockRecoveryReaderEx{ctrl: ctrl}
+	mock.recorder = &MockRecoveryReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockRecoveryReaderEx) EXPECT() *MockRecoveryReaderExMockRecorder {
+	return m.recorder
+}
+
+// ListRecoveryEx mocks base method
 func (m *MockRecoveryReaderEx) ListRecoveryEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRecoveryEx", ctx, query)
@@ -2795,36 +2839,51 @@ func (m *MockRecoveryReaderEx) ListRecoveryEx(ctx context.Context, query *query.
 	return ret0, ret1
 }
 
-// ListRecoveryEx indicates an expected call of ListRecoveryEx.
+// ListRecoveryEx indicates an expected call of ListRecoveryEx
 func (mr *MockRecoveryReaderExMockRecorder) ListRecoveryEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveryEx", reflect.TypeOf((*MockRecoveryReaderEx)(nil).ListRecoveryEx), ctx, query)
 }
 
-// MockRecoveryWriter is a mock of RecoveryWriter interface.
+// GetRecoveryEx mocks base method
+func (m *MockRecoveryReaderEx) GetRecoveryEx(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecoveryEx", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Recovery)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRecoveryEx indicates an expected call of GetRecoveryEx
+func (mr *MockRecoveryReaderExMockRecorder) GetRecoveryEx(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecoveryEx", reflect.TypeOf((*MockRecoveryReaderEx)(nil).GetRecoveryEx), ctx, cluster, name)
+}
+
+// MockRecoveryWriter is a mock of RecoveryWriter interface
 type MockRecoveryWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockRecoveryWriterMockRecorder
 }
 
-// MockRecoveryWriterMockRecorder is the mock recorder for MockRecoveryWriter.
+// MockRecoveryWriterMockRecorder is the mock recorder for MockRecoveryWriter
 type MockRecoveryWriterMockRecorder struct {
 	mock *MockRecoveryWriter
 }
 
-// NewMockRecoveryWriter creates a new mock instance.
+// NewMockRecoveryWriter creates a new mock instance
 func NewMockRecoveryWriter(ctrl *gomock.Controller) *MockRecoveryWriter {
 	mock := &MockRecoveryWriter{ctrl: ctrl}
 	mock.recorder = &MockRecoveryWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockRecoveryWriter) EXPECT() *MockRecoveryWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateRecovery mocks base method.
+// CreateRecovery mocks base method
 func (m *MockRecoveryWriter) CreateRecovery(ctc context.Context, recovery *v1.Recovery) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRecovery", ctc, recovery)
@@ -2833,27 +2892,13 @@ func (m *MockRecoveryWriter) CreateRecovery(ctc context.Context, recovery *v1.Re
 	return ret0, ret1
 }
 
-// CreateRecovery indicates an expected call of CreateRecovery.
+// CreateRecovery indicates an expected call of CreateRecovery
 func (mr *MockRecoveryWriterMockRecorder) CreateRecovery(ctc, recovery interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).CreateRecovery), ctc, recovery)
 }
 
-// DeleteRecovery mocks base method.
-func (m *MockRecoveryWriter) DeleteRecovery(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRecovery", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRecovery indicates an expected call of DeleteRecovery.
-func (mr *MockRecoveryWriterMockRecorder) DeleteRecovery(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).DeleteRecovery), ctx, name)
-}
-
-// UpdateRecovery mocks base method.
+// UpdateRecovery mocks base method
 func (m *MockRecoveryWriter) UpdateRecovery(ctx context.Context, recovery *v1.Recovery) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRecovery", ctx, recovery)
@@ -2862,51 +2907,50 @@ func (m *MockRecoveryWriter) UpdateRecovery(ctx context.Context, recovery *v1.Re
 	return ret0, ret1
 }
 
-// UpdateRecovery indicates an expected call of UpdateRecovery.
+// UpdateRecovery indicates an expected call of UpdateRecovery
 func (mr *MockRecoveryWriterMockRecorder) UpdateRecovery(ctx, recovery interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).UpdateRecovery), ctx, recovery)
 }
 
-// MockBackupPointReaderEx is a mock of BackupPointReaderEx interface.
+// DeleteRecovery mocks base method
+func (m *MockRecoveryWriter) DeleteRecovery(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRecovery", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRecovery indicates an expected call of DeleteRecovery
+func (mr *MockRecoveryWriterMockRecorder) DeleteRecovery(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).DeleteRecovery), ctx, name)
+}
+
+// MockBackupPointReaderEx is a mock of BackupPointReaderEx interface
 type MockBackupPointReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupPointReaderExMockRecorder
 }
 
-// MockBackupPointReaderExMockRecorder is the mock recorder for MockBackupPointReaderEx.
+// MockBackupPointReaderExMockRecorder is the mock recorder for MockBackupPointReaderEx
 type MockBackupPointReaderExMockRecorder struct {
 	mock *MockBackupPointReaderEx
 }
 
-// NewMockBackupPointReaderEx creates a new mock instance.
+// NewMockBackupPointReaderEx creates a new mock instance
 func NewMockBackupPointReaderEx(ctrl *gomock.Controller) *MockBackupPointReaderEx {
 	mock := &MockBackupPointReaderEx{ctrl: ctrl}
 	mock.recorder = &MockBackupPointReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockBackupPointReaderEx) EXPECT() *MockBackupPointReaderExMockRecorder {
 	return m.recorder
 }
 
-// GetBackupPointEx mocks base method.
-func (m *MockBackupPointReaderEx) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupPointEx indicates an expected call of GetBackupPointEx.
-func (mr *MockBackupPointReaderExMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockBackupPointReaderEx)(nil).GetBackupPointEx), ctx, name, resourceVersion)
-}
-
-// ListBackupPointEx mocks base method.
+// ListBackupPointEx mocks base method
 func (m *MockBackupPointReaderEx) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
@@ -2915,52 +2959,14 @@ func (m *MockBackupPointReaderEx) ListBackupPointEx(ctx context.Context, query *
 	return ret0, ret1
 }
 
-// ListBackupPointEx indicates an expected call of ListBackupPointEx.
+// ListBackupPointEx indicates an expected call of ListBackupPointEx
 func (mr *MockBackupPointReaderExMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockBackupPointReaderEx)(nil).ListBackupPointEx), ctx, query)
 }
 
-// MockBackupPointReader is a mock of BackupPointReader interface.
-type MockBackupPointReader struct {
-	ctrl     *gomock.Controller
-	recorder *MockBackupPointReaderMockRecorder
-}
-
-// MockBackupPointReaderMockRecorder is the mock recorder for MockBackupPointReader.
-type MockBackupPointReaderMockRecorder struct {
-	mock *MockBackupPointReader
-}
-
-// NewMockBackupPointReader creates a new mock instance.
-func NewMockBackupPointReader(ctrl *gomock.Controller) *MockBackupPointReader {
-	mock := &MockBackupPointReader{ctrl: ctrl}
-	mock.recorder = &MockBackupPointReaderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockBackupPointReader) EXPECT() *MockBackupPointReaderMockRecorder {
-	return m.recorder
-}
-
-// GetBackupPoint mocks base method.
-func (m *MockBackupPointReader) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupPoint indicates an expected call of GetBackupPoint.
-func (mr *MockBackupPointReaderMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockBackupPointReader)(nil).GetBackupPoint), ctx, name, resourceVersion)
-}
-
-// GetBackupPointEx mocks base method.
-func (m *MockBackupPointReader) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+// GetBackupPointEx mocks base method
+func (m *MockBackupPointReaderEx) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
 	ret0, _ := ret[0].(*v1.BackupPoint)
@@ -2968,28 +2974,36 @@ func (m *MockBackupPointReader) GetBackupPointEx(ctx context.Context, name, reso
 	return ret0, ret1
 }
 
-// GetBackupPointEx indicates an expected call of GetBackupPointEx.
-func (mr *MockBackupPointReaderMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+// GetBackupPointEx indicates an expected call of GetBackupPointEx
+func (mr *MockBackupPointReaderExMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockBackupPointReader)(nil).GetBackupPointEx), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockBackupPointReaderEx)(nil).GetBackupPointEx), ctx, name, resourceVersion)
 }
 
-// ListBackupPointEx mocks base method.
-func (m *MockBackupPointReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+// MockBackupPointReader is a mock of BackupPointReader interface
+type MockBackupPointReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockBackupPointReaderMockRecorder
 }
 
-// ListBackupPointEx indicates an expected call of ListBackupPointEx.
-func (mr *MockBackupPointReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockBackupPointReader)(nil).ListBackupPointEx), ctx, query)
+// MockBackupPointReaderMockRecorder is the mock recorder for MockBackupPointReader
+type MockBackupPointReaderMockRecorder struct {
+	mock *MockBackupPointReader
 }
 
-// ListBackupPoints mocks base method.
+// NewMockBackupPointReader creates a new mock instance
+func NewMockBackupPointReader(ctrl *gomock.Controller) *MockBackupPointReader {
+	mock := &MockBackupPointReader{ctrl: ctrl}
+	mock.recorder = &MockBackupPointReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockBackupPointReader) EXPECT() *MockBackupPointReaderMockRecorder {
+	return m.recorder
+}
+
+// ListBackupPoints mocks base method
 func (m *MockBackupPointReader) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
@@ -2998,36 +3012,96 @@ func (m *MockBackupPointReader) ListBackupPoints(ctx context.Context, query *que
 	return ret0, ret1
 }
 
-// ListBackupPoints indicates an expected call of ListBackupPoints.
+// ListBackupPoints indicates an expected call of ListBackupPoints
 func (mr *MockBackupPointReaderMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockBackupPointReader)(nil).ListBackupPoints), ctx, query)
 }
 
-// MockBackupPointWriter is a mock of BackupPointWriter interface.
+// GetBackupPoint mocks base method
+func (m *MockBackupPointReader) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPoint indicates an expected call of GetBackupPoint
+func (mr *MockBackupPointReaderMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockBackupPointReader)(nil).GetBackupPoint), ctx, name, resourceVersion)
+}
+
+// WatchBackupPoints mocks base method
+func (m *MockBackupPointReader) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackupPoints indicates an expected call of WatchBackupPoints
+func (mr *MockBackupPointReaderMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockBackupPointReader)(nil).WatchBackupPoints), ctx, query)
+}
+
+// ListBackupPointEx mocks base method
+func (m *MockBackupPointReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPointEx indicates an expected call of ListBackupPointEx
+func (mr *MockBackupPointReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockBackupPointReader)(nil).ListBackupPointEx), ctx, query)
+}
+
+// GetBackupPointEx mocks base method
+func (m *MockBackupPointReader) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPointEx indicates an expected call of GetBackupPointEx
+func (mr *MockBackupPointReaderMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockBackupPointReader)(nil).GetBackupPointEx), ctx, name, resourceVersion)
+}
+
+// MockBackupPointWriter is a mock of BackupPointWriter interface
 type MockBackupPointWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupPointWriterMockRecorder
 }
 
-// MockBackupPointWriterMockRecorder is the mock recorder for MockBackupPointWriter.
+// MockBackupPointWriterMockRecorder is the mock recorder for MockBackupPointWriter
 type MockBackupPointWriterMockRecorder struct {
 	mock *MockBackupPointWriter
 }
 
-// NewMockBackupPointWriter creates a new mock instance.
+// NewMockBackupPointWriter creates a new mock instance
 func NewMockBackupPointWriter(ctrl *gomock.Controller) *MockBackupPointWriter {
 	mock := &MockBackupPointWriter{ctrl: ctrl}
 	mock.recorder = &MockBackupPointWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockBackupPointWriter) EXPECT() *MockBackupPointWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateBackupPoint mocks base method.
+// CreateBackupPoint mocks base method
 func (m *MockBackupPointWriter) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
@@ -3036,27 +3110,13 @@ func (m *MockBackupPointWriter) CreateBackupPoint(ctx context.Context, backupPoi
 	return ret0, ret1
 }
 
-// CreateBackupPoint indicates an expected call of CreateBackupPoint.
+// CreateBackupPoint indicates an expected call of CreateBackupPoint
 func (mr *MockBackupPointWriterMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).CreateBackupPoint), ctx, backupPoint)
 }
 
-// DeleteBackupPoint mocks base method.
-func (m *MockBackupPointWriter) DeleteBackupPoint(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackupPoint indicates an expected call of DeleteBackupPoint.
-func (mr *MockBackupPointWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).DeleteBackupPoint), ctx, name)
-}
-
-// UpdateBackupPoint mocks base method.
+// UpdateBackupPoint mocks base method
 func (m *MockBackupPointWriter) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
@@ -3065,51 +3125,50 @@ func (m *MockBackupPointWriter) UpdateBackupPoint(ctx context.Context, backupPoi
 	return ret0, ret1
 }
 
-// UpdateBackupPoint indicates an expected call of UpdateBackupPoint.
+// UpdateBackupPoint indicates an expected call of UpdateBackupPoint
 func (mr *MockBackupPointWriterMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).UpdateBackupPoint), ctx, backupPoint)
 }
 
-// MockCronBackupReaderEx is a mock of CronBackupReaderEx interface.
+// DeleteBackupPoint mocks base method
+func (m *MockBackupPointWriter) DeleteBackupPoint(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackupPoint indicates an expected call of DeleteBackupPoint
+func (mr *MockBackupPointWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).DeleteBackupPoint), ctx, name)
+}
+
+// MockCronBackupReaderEx is a mock of CronBackupReaderEx interface
 type MockCronBackupReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockCronBackupReaderExMockRecorder
 }
 
-// MockCronBackupReaderExMockRecorder is the mock recorder for MockCronBackupReaderEx.
+// MockCronBackupReaderExMockRecorder is the mock recorder for MockCronBackupReaderEx
 type MockCronBackupReaderExMockRecorder struct {
 	mock *MockCronBackupReaderEx
 }
 
-// NewMockCronBackupReaderEx creates a new mock instance.
+// NewMockCronBackupReaderEx creates a new mock instance
 func NewMockCronBackupReaderEx(ctrl *gomock.Controller) *MockCronBackupReaderEx {
 	mock := &MockCronBackupReaderEx{ctrl: ctrl}
 	mock.recorder = &MockCronBackupReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCronBackupReaderEx) EXPECT() *MockCronBackupReaderExMockRecorder {
 	return m.recorder
 }
 
-// GetCronBackupEx mocks base method.
-func (m *MockCronBackupReaderEx) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCronBackupEx indicates an expected call of GetCronBackupEx.
-func (mr *MockCronBackupReaderExMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockCronBackupReaderEx)(nil).GetCronBackupEx), ctx, name, resourceVersion)
-}
-
-// ListCronBackupEx mocks base method.
+// ListCronBackupEx mocks base method
 func (m *MockCronBackupReaderEx) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
@@ -3118,52 +3177,14 @@ func (m *MockCronBackupReaderEx) ListCronBackupEx(ctx context.Context, query *qu
 	return ret0, ret1
 }
 
-// ListCronBackupEx indicates an expected call of ListCronBackupEx.
+// ListCronBackupEx indicates an expected call of ListCronBackupEx
 func (mr *MockCronBackupReaderExMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockCronBackupReaderEx)(nil).ListCronBackupEx), ctx, query)
 }
 
-// MockCronBackupReader is a mock of CronBackupReader interface.
-type MockCronBackupReader struct {
-	ctrl     *gomock.Controller
-	recorder *MockCronBackupReaderMockRecorder
-}
-
-// MockCronBackupReaderMockRecorder is the mock recorder for MockCronBackupReader.
-type MockCronBackupReaderMockRecorder struct {
-	mock *MockCronBackupReader
-}
-
-// NewMockCronBackupReader creates a new mock instance.
-func NewMockCronBackupReader(ctrl *gomock.Controller) *MockCronBackupReader {
-	mock := &MockCronBackupReader{ctrl: ctrl}
-	mock.recorder = &MockCronBackupReaderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockCronBackupReader) EXPECT() *MockCronBackupReaderMockRecorder {
-	return m.recorder
-}
-
-// GetCronBackup mocks base method.
-func (m *MockCronBackupReader) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCronBackup indicates an expected call of GetCronBackup.
-func (mr *MockCronBackupReaderMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockCronBackupReader)(nil).GetCronBackup), ctx, name, resourceVersion)
-}
-
-// GetCronBackupEx mocks base method.
-func (m *MockCronBackupReader) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+// GetCronBackupEx mocks base method
+func (m *MockCronBackupReaderEx) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
 	ret0, _ := ret[0].(*v1.CronBackup)
@@ -3171,28 +3192,36 @@ func (m *MockCronBackupReader) GetCronBackupEx(ctx context.Context, name, resour
 	return ret0, ret1
 }
 
-// GetCronBackupEx indicates an expected call of GetCronBackupEx.
-func (mr *MockCronBackupReaderMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+// GetCronBackupEx indicates an expected call of GetCronBackupEx
+func (mr *MockCronBackupReaderExMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockCronBackupReader)(nil).GetCronBackupEx), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockCronBackupReaderEx)(nil).GetCronBackupEx), ctx, name, resourceVersion)
 }
 
-// ListCronBackupEx mocks base method.
-func (m *MockCronBackupReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+// MockCronBackupReader is a mock of CronBackupReader interface
+type MockCronBackupReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockCronBackupReaderMockRecorder
 }
 
-// ListCronBackupEx indicates an expected call of ListCronBackupEx.
-func (mr *MockCronBackupReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockCronBackupReader)(nil).ListCronBackupEx), ctx, query)
+// MockCronBackupReaderMockRecorder is the mock recorder for MockCronBackupReader
+type MockCronBackupReaderMockRecorder struct {
+	mock *MockCronBackupReader
 }
 
-// ListCronBackups mocks base method.
+// NewMockCronBackupReader creates a new mock instance
+func NewMockCronBackupReader(ctrl *gomock.Controller) *MockCronBackupReader {
+	mock := &MockCronBackupReader{ctrl: ctrl}
+	mock.recorder = &MockCronBackupReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockCronBackupReader) EXPECT() *MockCronBackupReaderMockRecorder {
+	return m.recorder
+}
+
+// ListCronBackups mocks base method
 func (m *MockCronBackupReader) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
@@ -3201,36 +3230,96 @@ func (m *MockCronBackupReader) ListCronBackups(ctx context.Context, query *query
 	return ret0, ret1
 }
 
-// ListCronBackups indicates an expected call of ListCronBackups.
+// ListCronBackups indicates an expected call of ListCronBackups
 func (mr *MockCronBackupReaderMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockCronBackupReader)(nil).ListCronBackups), ctx, query)
 }
 
-// MockCronBackupWriter is a mock of CronBackupWriter interface.
+// GetCronBackup mocks base method
+func (m *MockCronBackupReader) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackup indicates an expected call of GetCronBackup
+func (mr *MockCronBackupReaderMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockCronBackupReader)(nil).GetCronBackup), ctx, name, resourceVersion)
+}
+
+// WatchCronBackups mocks base method
+func (m *MockCronBackupReader) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchCronBackups indicates an expected call of WatchCronBackups
+func (mr *MockCronBackupReaderMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockCronBackupReader)(nil).WatchCronBackups), ctx, query)
+}
+
+// ListCronBackupEx mocks base method
+func (m *MockCronBackupReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackupEx indicates an expected call of ListCronBackupEx
+func (mr *MockCronBackupReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockCronBackupReader)(nil).ListCronBackupEx), ctx, query)
+}
+
+// GetCronBackupEx mocks base method
+func (m *MockCronBackupReader) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackupEx indicates an expected call of GetCronBackupEx
+func (mr *MockCronBackupReaderMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockCronBackupReader)(nil).GetCronBackupEx), ctx, name, resourceVersion)
+}
+
+// MockCronBackupWriter is a mock of CronBackupWriter interface
 type MockCronBackupWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockCronBackupWriterMockRecorder
 }
 
-// MockCronBackupWriterMockRecorder is the mock recorder for MockCronBackupWriter.
+// MockCronBackupWriterMockRecorder is the mock recorder for MockCronBackupWriter
 type MockCronBackupWriterMockRecorder struct {
 	mock *MockCronBackupWriter
 }
 
-// NewMockCronBackupWriter creates a new mock instance.
+// NewMockCronBackupWriter creates a new mock instance
 func NewMockCronBackupWriter(ctrl *gomock.Controller) *MockCronBackupWriter {
 	mock := &MockCronBackupWriter{ctrl: ctrl}
 	mock.recorder = &MockCronBackupWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCronBackupWriter) EXPECT() *MockCronBackupWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateCronBackup mocks base method.
+// CreateCronBackup mocks base method
 func (m *MockCronBackupWriter) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
@@ -3239,27 +3328,13 @@ func (m *MockCronBackupWriter) CreateCronBackup(ctx context.Context, cronBackup 
 	return ret0, ret1
 }
 
-// CreateCronBackup indicates an expected call of CreateCronBackup.
+// CreateCronBackup indicates an expected call of CreateCronBackup
 func (mr *MockCronBackupWriterMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).CreateCronBackup), ctx, cronBackup)
 }
 
-// DeleteCronBackup mocks base method.
-func (m *MockCronBackupWriter) DeleteCronBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCronBackup indicates an expected call of DeleteCronBackup.
-func (mr *MockCronBackupWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).DeleteCronBackup), ctx, name)
-}
-
-// UpdateCronBackup mocks base method.
+// UpdateCronBackup mocks base method
 func (m *MockCronBackupWriter) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
@@ -3268,51 +3343,50 @@ func (m *MockCronBackupWriter) UpdateCronBackup(ctx context.Context, cronBackup 
 	return ret0, ret1
 }
 
-// UpdateCronBackup indicates an expected call of UpdateCronBackup.
+// UpdateCronBackup indicates an expected call of UpdateCronBackup
 func (mr *MockCronBackupWriterMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).UpdateCronBackup), ctx, cronBackup)
 }
 
-// MockDNSReader is a mock of DNSReader interface.
+// DeleteCronBackup mocks base method
+func (m *MockCronBackupWriter) DeleteCronBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackup indicates an expected call of DeleteCronBackup
+func (mr *MockCronBackupWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).DeleteCronBackup), ctx, name)
+}
+
+// MockDNSReader is a mock of DNSReader interface
 type MockDNSReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockDNSReaderMockRecorder
 }
 
-// MockDNSReaderMockRecorder is the mock recorder for MockDNSReader.
+// MockDNSReaderMockRecorder is the mock recorder for MockDNSReader
 type MockDNSReaderMockRecorder struct {
 	mock *MockDNSReader
 }
 
-// NewMockDNSReader creates a new mock instance.
+// NewMockDNSReader creates a new mock instance
 func NewMockDNSReader(ctrl *gomock.Controller) *MockDNSReader {
 	mock := &MockDNSReader{ctrl: ctrl}
 	mock.recorder = &MockDNSReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockDNSReader) EXPECT() *MockDNSReaderMockRecorder {
 	return m.recorder
 }
 
-// GetDomain mocks base method.
-func (m *MockDNSReader) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
-	ret0, _ := ret[0].(*v1.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDomain indicates an expected call of GetDomain.
-func (mr *MockDNSReaderMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockDNSReader)(nil).GetDomain), ctx, name)
-}
-
-// ListDomains mocks base method.
+// ListDomains mocks base method
 func (m *MockDNSReader) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
@@ -3321,43 +3395,28 @@ func (m *MockDNSReader) ListDomains(ctx context.Context, query *query.Query) (*v
 	return ret0, ret1
 }
 
-// ListDomains indicates an expected call of ListDomains.
+// ListDomains indicates an expected call of ListDomains
 func (mr *MockDNSReaderMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockDNSReader)(nil).ListDomains), ctx, query)
 }
 
-// ListDomainsEx mocks base method.
-func (m *MockDNSReader) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+// GetDomain mocks base method
+func (m *MockDNSReader) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
+	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
+	ret0, _ := ret[0].(*v1.Domain)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListDomainsEx indicates an expected call of ListDomainsEx.
-func (mr *MockDNSReaderMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
+// GetDomain indicates an expected call of GetDomain
+func (mr *MockDNSReaderMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockDNSReader)(nil).ListDomainsEx), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockDNSReader)(nil).GetDomain), ctx, name)
 }
 
-// ListRecordsEx mocks base method.
-func (m *MockDNSReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecordsEx indicates an expected call of ListRecordsEx.
-func (mr *MockDNSReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockDNSReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
-}
-
-// WatchDomain mocks base method.
+// WatchDomain mocks base method
 func (m *MockDNSReader) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
@@ -3366,37 +3425,29 @@ func (m *MockDNSReader) WatchDomain(ctx context.Context, query *query.Query) (wa
 	return ret0, ret1
 }
 
-// WatchDomain indicates an expected call of WatchDomain.
+// WatchDomain indicates an expected call of WatchDomain
 func (mr *MockDNSReaderMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockDNSReader)(nil).WatchDomain), ctx, query)
 }
 
-// MockDNSReaderEx is a mock of DNSReaderEx interface.
-type MockDNSReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockDNSReaderExMockRecorder
+// ListRecordsEx mocks base method
+func (m *MockDNSReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// MockDNSReaderExMockRecorder is the mock recorder for MockDNSReaderEx.
-type MockDNSReaderExMockRecorder struct {
-	mock *MockDNSReaderEx
+// ListRecordsEx indicates an expected call of ListRecordsEx
+func (mr *MockDNSReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockDNSReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
 }
 
-// NewMockDNSReaderEx creates a new mock instance.
-func NewMockDNSReaderEx(ctrl *gomock.Controller) *MockDNSReaderEx {
-	mock := &MockDNSReaderEx{ctrl: ctrl}
-	mock.recorder = &MockDNSReaderExMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockDNSReaderEx) EXPECT() *MockDNSReaderExMockRecorder {
-	return m.recorder
-}
-
-// ListDomainsEx mocks base method.
-func (m *MockDNSReaderEx) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+// ListDomainsEx mocks base method
+func (m *MockDNSReader) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
 	ret0, _ := ret[0].(*models.PageableResponse)
@@ -3404,13 +3455,36 @@ func (m *MockDNSReaderEx) ListDomainsEx(ctx context.Context, query *query.Query)
 	return ret0, ret1
 }
 
-// ListDomainsEx indicates an expected call of ListDomainsEx.
-func (mr *MockDNSReaderExMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
+// ListDomainsEx indicates an expected call of ListDomainsEx
+func (mr *MockDNSReaderMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockDNSReaderEx)(nil).ListDomainsEx), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockDNSReader)(nil).ListDomainsEx), ctx, query)
 }
 
-// ListRecordsEx mocks base method.
+// MockDNSReaderEx is a mock of DNSReaderEx interface
+type MockDNSReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockDNSReaderExMockRecorder
+}
+
+// MockDNSReaderExMockRecorder is the mock recorder for MockDNSReaderEx
+type MockDNSReaderExMockRecorder struct {
+	mock *MockDNSReaderEx
+}
+
+// NewMockDNSReaderEx creates a new mock instance
+func NewMockDNSReaderEx(ctrl *gomock.Controller) *MockDNSReaderEx {
+	mock := &MockDNSReaderEx{ctrl: ctrl}
+	mock.recorder = &MockDNSReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockDNSReaderEx) EXPECT() *MockDNSReaderExMockRecorder {
+	return m.recorder
+}
+
+// ListRecordsEx mocks base method
 func (m *MockDNSReaderEx) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
@@ -3419,36 +3493,51 @@ func (m *MockDNSReaderEx) ListRecordsEx(ctx context.Context, name, subdomain str
 	return ret0, ret1
 }
 
-// ListRecordsEx indicates an expected call of ListRecordsEx.
+// ListRecordsEx indicates an expected call of ListRecordsEx
 func (mr *MockDNSReaderExMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockDNSReaderEx)(nil).ListRecordsEx), ctx, name, subdomain, query)
 }
 
-// MockDNSWriter is a mock of DNSWriter interface.
+// ListDomainsEx mocks base method
+func (m *MockDNSReaderEx) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomainsEx indicates an expected call of ListDomainsEx
+func (mr *MockDNSReaderExMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockDNSReaderEx)(nil).ListDomainsEx), ctx, query)
+}
+
+// MockDNSWriter is a mock of DNSWriter interface
 type MockDNSWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockDNSWriterMockRecorder
 }
 
-// MockDNSWriterMockRecorder is the mock recorder for MockDNSWriter.
+// MockDNSWriterMockRecorder is the mock recorder for MockDNSWriter
 type MockDNSWriterMockRecorder struct {
 	mock *MockDNSWriter
 }
 
-// NewMockDNSWriter creates a new mock instance.
+// NewMockDNSWriter creates a new mock instance
 func NewMockDNSWriter(ctrl *gomock.Controller) *MockDNSWriter {
 	mock := &MockDNSWriter{ctrl: ctrl}
 	mock.recorder = &MockDNSWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockDNSWriter) EXPECT() *MockDNSWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateDomain mocks base method.
+// CreateDomain mocks base method
 func (m *MockDNSWriter) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
@@ -3457,27 +3546,13 @@ func (m *MockDNSWriter) CreateDomain(ctc context.Context, domain *v1.Domain) (*v
 	return ret0, ret1
 }
 
-// CreateDomain indicates an expected call of CreateDomain.
+// CreateDomain indicates an expected call of CreateDomain
 func (mr *MockDNSWriterMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockDNSWriter)(nil).CreateDomain), ctc, domain)
 }
 
-// DeleteDomain mocks base method.
-func (m *MockDNSWriter) DeleteDomain(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteDomain indicates an expected call of DeleteDomain.
-func (mr *MockDNSWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockDNSWriter)(nil).DeleteDomain), ctx, name)
-}
-
-// UpdateDomain mocks base method.
+// UpdateDomain mocks base method
 func (m *MockDNSWriter) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
@@ -3486,66 +3561,50 @@ func (m *MockDNSWriter) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v
 	return ret0, ret1
 }
 
-// UpdateDomain indicates an expected call of UpdateDomain.
+// UpdateDomain indicates an expected call of UpdateDomain
 func (mr *MockDNSWriterMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockDNSWriter)(nil).UpdateDomain), ctx, domain)
 }
 
-// MockTemplateReader is a mock of TemplateReader interface.
+// DeleteDomain mocks base method
+func (m *MockDNSWriter) DeleteDomain(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDomain indicates an expected call of DeleteDomain
+func (mr *MockDNSWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockDNSWriter)(nil).DeleteDomain), ctx, name)
+}
+
+// MockTemplateReader is a mock of TemplateReader interface
 type MockTemplateReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockTemplateReaderMockRecorder
 }
 
-// MockTemplateReaderMockRecorder is the mock recorder for MockTemplateReader.
+// MockTemplateReaderMockRecorder is the mock recorder for MockTemplateReader
 type MockTemplateReaderMockRecorder struct {
 	mock *MockTemplateReader
 }
 
-// NewMockTemplateReader creates a new mock instance.
+// NewMockTemplateReader creates a new mock instance
 func NewMockTemplateReader(ctrl *gomock.Controller) *MockTemplateReader {
 	mock := &MockTemplateReader{ctrl: ctrl}
 	mock.recorder = &MockTemplateReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockTemplateReader) EXPECT() *MockTemplateReaderMockRecorder {
 	return m.recorder
 }
 
-// GetTemplate mocks base method.
-func (m *MockTemplateReader) GetTemplate(ctx context.Context, name string) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplate", ctx, name)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTemplate indicates an expected call of GetTemplate.
-func (mr *MockTemplateReaderMockRecorder) GetTemplate(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockTemplateReader)(nil).GetTemplate), ctx, name)
-}
-
-// GetTemplateEx mocks base method.
-func (m *MockTemplateReader) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTemplateEx indicates an expected call of GetTemplateEx.
-func (mr *MockTemplateReaderMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockTemplateReader)(nil).GetTemplateEx), ctx, name, resourceVersion)
-}
-
-// ListTemplates mocks base method.
+// ListTemplates mocks base method
 func (m *MockTemplateReader) ListTemplates(ctx context.Context, query *query.Query) (*v1.TemplateList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTemplates", ctx, query)
@@ -3554,28 +3613,13 @@ func (m *MockTemplateReader) ListTemplates(ctx context.Context, query *query.Que
 	return ret0, ret1
 }
 
-// ListTemplates indicates an expected call of ListTemplates.
+// ListTemplates indicates an expected call of ListTemplates
 func (mr *MockTemplateReaderMockRecorder) ListTemplates(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplates", reflect.TypeOf((*MockTemplateReader)(nil).ListTemplates), ctx, query)
 }
 
-// ListTemplatesEx mocks base method.
-func (m *MockTemplateReader) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTemplatesEx indicates an expected call of ListTemplatesEx.
-func (mr *MockTemplateReaderMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockTemplateReader)(nil).ListTemplatesEx), ctx, query)
-}
-
-// WatchTemplates mocks base method.
+// WatchTemplates mocks base method
 func (m *MockTemplateReader) WatchTemplates(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchTemplates", ctx, query)
@@ -3584,37 +3628,44 @@ func (m *MockTemplateReader) WatchTemplates(ctx context.Context, query *query.Qu
 	return ret0, ret1
 }
 
-// WatchTemplates indicates an expected call of WatchTemplates.
+// WatchTemplates indicates an expected call of WatchTemplates
 func (mr *MockTemplateReaderMockRecorder) WatchTemplates(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTemplates", reflect.TypeOf((*MockTemplateReader)(nil).WatchTemplates), ctx, query)
 }
 
-// MockTemplateReaderEx is a mock of TemplateReaderEx interface.
-type MockTemplateReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockTemplateReaderExMockRecorder
+// GetTemplate mocks base method
+func (m *MockTemplateReader) GetTemplate(ctx context.Context, name string) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplate", ctx, name)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// MockTemplateReaderExMockRecorder is the mock recorder for MockTemplateReaderEx.
-type MockTemplateReaderExMockRecorder struct {
-	mock *MockTemplateReaderEx
+// GetTemplate indicates an expected call of GetTemplate
+func (mr *MockTemplateReaderMockRecorder) GetTemplate(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockTemplateReader)(nil).GetTemplate), ctx, name)
 }
 
-// NewMockTemplateReaderEx creates a new mock instance.
-func NewMockTemplateReaderEx(ctrl *gomock.Controller) *MockTemplateReaderEx {
-	mock := &MockTemplateReaderEx{ctrl: ctrl}
-	mock.recorder = &MockTemplateReaderExMockRecorder{mock}
-	return mock
+// ListTemplatesEx mocks base method
+func (m *MockTemplateReader) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockTemplateReaderEx) EXPECT() *MockTemplateReaderExMockRecorder {
-	return m.recorder
+// ListTemplatesEx indicates an expected call of ListTemplatesEx
+func (mr *MockTemplateReaderMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockTemplateReader)(nil).ListTemplatesEx), ctx, query)
 }
 
-// GetTemplateEx mocks base method.
-func (m *MockTemplateReaderEx) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
+// GetTemplateEx mocks base method
+func (m *MockTemplateReader) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
 	ret0, _ := ret[0].(*v1.Template)
@@ -3622,13 +3673,36 @@ func (m *MockTemplateReaderEx) GetTemplateEx(ctx context.Context, name, resource
 	return ret0, ret1
 }
 
-// GetTemplateEx indicates an expected call of GetTemplateEx.
-func (mr *MockTemplateReaderExMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+// GetTemplateEx indicates an expected call of GetTemplateEx
+func (mr *MockTemplateReaderMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockTemplateReaderEx)(nil).GetTemplateEx), ctx, name, resourceVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockTemplateReader)(nil).GetTemplateEx), ctx, name, resourceVersion)
 }
 
-// ListTemplatesEx mocks base method.
+// MockTemplateReaderEx is a mock of TemplateReaderEx interface
+type MockTemplateReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockTemplateReaderExMockRecorder
+}
+
+// MockTemplateReaderExMockRecorder is the mock recorder for MockTemplateReaderEx
+type MockTemplateReaderExMockRecorder struct {
+	mock *MockTemplateReaderEx
+}
+
+// NewMockTemplateReaderEx creates a new mock instance
+func NewMockTemplateReaderEx(ctrl *gomock.Controller) *MockTemplateReaderEx {
+	mock := &MockTemplateReaderEx{ctrl: ctrl}
+	mock.recorder = &MockTemplateReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockTemplateReaderEx) EXPECT() *MockTemplateReaderExMockRecorder {
+	return m.recorder
+}
+
+// ListTemplatesEx mocks base method
 func (m *MockTemplateReaderEx) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
@@ -3637,36 +3711,51 @@ func (m *MockTemplateReaderEx) ListTemplatesEx(ctx context.Context, query *query
 	return ret0, ret1
 }
 
-// ListTemplatesEx indicates an expected call of ListTemplatesEx.
+// ListTemplatesEx indicates an expected call of ListTemplatesEx
 func (mr *MockTemplateReaderExMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockTemplateReaderEx)(nil).ListTemplatesEx), ctx, query)
 }
 
-// MockTemplateWriter is a mock of TemplateWriter interface.
+// GetTemplateEx mocks base method
+func (m *MockTemplateReaderEx) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemplateEx indicates an expected call of GetTemplateEx
+func (mr *MockTemplateReaderExMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockTemplateReaderEx)(nil).GetTemplateEx), ctx, name, resourceVersion)
+}
+
+// MockTemplateWriter is a mock of TemplateWriter interface
 type MockTemplateWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockTemplateWriterMockRecorder
 }
 
-// MockTemplateWriterMockRecorder is the mock recorder for MockTemplateWriter.
+// MockTemplateWriterMockRecorder is the mock recorder for MockTemplateWriter
 type MockTemplateWriterMockRecorder struct {
 	mock *MockTemplateWriter
 }
 
-// NewMockTemplateWriter creates a new mock instance.
+// NewMockTemplateWriter creates a new mock instance
 func NewMockTemplateWriter(ctrl *gomock.Controller) *MockTemplateWriter {
 	mock := &MockTemplateWriter{ctrl: ctrl}
 	mock.recorder = &MockTemplateWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockTemplateWriter) EXPECT() *MockTemplateWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateTemplate mocks base method.
+// CreateTemplate mocks base method
 func (m *MockTemplateWriter) CreateTemplate(ctc context.Context, template *v1.Template) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTemplate", ctc, template)
@@ -3675,41 +3764,13 @@ func (m *MockTemplateWriter) CreateTemplate(ctc context.Context, template *v1.Te
 	return ret0, ret1
 }
 
-// CreateTemplate indicates an expected call of CreateTemplate.
+// CreateTemplate indicates an expected call of CreateTemplate
 func (mr *MockTemplateWriterMockRecorder) CreateTemplate(ctc, template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).CreateTemplate), ctc, template)
 }
 
-// DeleteTemplate mocks base method.
-func (m *MockTemplateWriter) DeleteTemplate(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplate indicates an expected call of DeleteTemplate.
-func (mr *MockTemplateWriterMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplate), ctx, name)
-}
-
-// DeleteTemplateCollection mocks base method.
-func (m *MockTemplateWriter) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection.
-func (mr *MockTemplateWriterMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplateCollection), ctx, query)
-}
-
-// UpdateTemplate mocks base method.
+// UpdateTemplate mocks base method
 func (m *MockTemplateWriter) UpdateTemplate(ctx context.Context, template *v1.Template) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTemplate", ctx, template)
@@ -3718,8 +3779,36 @@ func (m *MockTemplateWriter) UpdateTemplate(ctx context.Context, template *v1.Te
 	return ret0, ret1
 }
 
-// UpdateTemplate indicates an expected call of UpdateTemplate.
+// UpdateTemplate indicates an expected call of UpdateTemplate
 func (mr *MockTemplateWriterMockRecorder) UpdateTemplate(ctx, template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).UpdateTemplate), ctx, template)
+}
+
+// DeleteTemplate mocks base method
+func (m *MockTemplateWriter) DeleteTemplate(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplate indicates an expected call of DeleteTemplate
+func (mr *MockTemplateWriterMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplate), ctx, name)
+}
+
+// DeleteTemplateCollection mocks base method
+func (m *MockTemplateWriter) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection
+func (mr *MockTemplateWriterMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplateCollection), ctx, query)
 }


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
backuppoint and cronbackup not impl watch func, controller reflect run not properly
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```