### PR TITLE
fix kcctl registry and resource subcommand

### DIFF
--- a/pkg/cli/registry/registry.go
+++ b/pkg/cli/registry/registry.go
@@ -188,7 +188,7 @@ func NewRegistryOptions(streams options.IOStreams) *RegistryOptions {
 		DataRoot:       "/var/lib/docker",
 		RegistryVolume: "/opt/registry",
 		RegistryPort:   5000,
-		Arch:           "x86_64",
+		Arch:           "amd64",
 		Tag:            "",
 		Number:         0,
 	}
@@ -377,8 +377,8 @@ func (o *RegistryOptions) preCheck() bool {
 }
 
 func (o *RegistryOptions) Complete() error {
-	if o.Arch == "" || o.Arch == "amd64" {
-		o.Arch = "x86_64"
+	if o.Arch == "" {
+		o.Arch = "amd64"
 	}
 	return nil
 }
@@ -741,8 +741,7 @@ func (o *RegistryOptions) installDocker() error {
 		}
 		cmdList := []string{
 			// cp docker service file
-			fmt.Sprintf("tar vxf %s/kc/resource/docker/19.03.12/%s/docker.tgz -C /tmp/", config.DefaultPkgPath, o.Arch),
-			fmt.Sprintf("cp -r /tmp/docker/* /usr/bin/ && cp %s/kc/resource/docker/19.03.12/%s/docker.service /etc/systemd/system/docker.service", config.DefaultPkgPath, o.Arch),
+			fmt.Sprintf("tar -zxvf %s/kc/resource/docker/19.03.12/%s/configs.tar.gz -C /", config.DefaultPkgPath, o.Arch),
 			"mkdir -pv /etc/docker",
 			// write daemon.json
 			sshutils.WrapEcho(data, "/etc/docker/daemon.json"),


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #50 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```