### PR TITLE
fix: delete backup operation name error

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -1242,7 +1242,7 @@ func (h *handler) DeleteBackup(request *restful.Request, response *restful.Respo
 	op := &v1.Operation{}
 	op.Name = uuid.New().String()
 	op.Labels = make(map[string]string)
-	op.Labels[common.LabelOperationAction] = v1.OperationBackupCluster
+	op.Labels[common.LabelOperationAction] = v1.OperationDeleteBackup
 	op.Labels[common.LabelTimeoutSeconds] = strconv.Itoa(v1.DefaultBackupTimeoutSec)
 	op.Labels[common.LabelClusterName] = c.Name
 	op.Labels[common.LabelBackupName] = b.Name

--- a/pkg/controller/cronbackupcontroller/controller.go
+++ b/pkg/controller/cronbackupcontroller/controller.go
@@ -456,7 +456,7 @@ func (r *CronBackupReconciler) deleteBackup(log logger.Logging, clusterName stri
 	op := &v1.Operation{}
 	op.Name = uuid.New().String()
 	op.Labels = make(map[string]string)
-	op.Labels[common.LabelOperationAction] = v1.OperationBackupCluster
+	op.Labels[common.LabelOperationAction] = v1.OperationDeleteBackup
 	op.Labels[common.LabelTimeoutSeconds] = strconv.Itoa(v1.DefaultBackupTimeoutSec)
 	op.Labels[common.LabelClusterName] = c.Name
 	op.Labels[common.LabelBackupName] = b.Name

--- a/pkg/scheme/core/v1/operation_types.go
+++ b/pkg/scheme/core/v1/operation_types.go
@@ -92,6 +92,7 @@ const (
 	OperationAddNodes            = "AddNodes"
 	OperationRemoveNodes         = "RemoveNodes"
 	OperationBackupCluster       = "BackupCluster"
+	OperationDeleteBackup        = "DeleteBackup"
 	OperationRecoverCluster      = "RecoveryCluster"
 	OperationInstallComponents   = "InstallComponents"
 	OperationUninstallComponents = "UninstallComponents"

--- a/pkg/service/delivery/delivery.go
+++ b/pkg/service/delivery/delivery.go
@@ -310,6 +310,10 @@ func (s *Service) syncClusterCondition(op *v1.Operation, clu *v1.Cluster) error 
 		clu.Status.Phase = v1.ClusterRunning
 		_, err := s.clusterOperator.UpdateCluster(context.TODO(), clu)
 		return err
+	case v1.OperationDeleteBackup:
+		clu.Status.Phase = v1.ClusterRunning
+		_, err := s.clusterOperator.UpdateCluster(context.TODO(), clu)
+		return err
 	case v1.OperationRecoverCluster:
 		if op.Status.Status == v1.OperationStatusSuccessful {
 			clu.Status.Phase = v1.ClusterRunning

--- a/pkg/service/delivery/delivery.go
+++ b/pkg/service/delivery/delivery.go
@@ -310,10 +310,6 @@ func (s *Service) syncClusterCondition(op *v1.Operation, clu *v1.Cluster) error 
 		clu.Status.Phase = v1.ClusterRunning
 		_, err := s.clusterOperator.UpdateCluster(context.TODO(), clu)
 		return err
-	case v1.OperationDeleteBackup:
-		clu.Status.Phase = v1.ClusterRunning
-		_, err := s.clusterOperator.UpdateCluster(context.TODO(), clu)
-		return err
 	case v1.OperationRecoverCluster:
 		if op.Status.Status == v1.OperationStatusSuccessful {
 			clu.Status.Phase = v1.ClusterRunning


### PR DESCRIPTION
Signed-off-by: liuchuwei <liu.chuwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
The operation name of the deleted backup is wrong

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubeclipper-labs/kubeclipper/issues/66

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```