### PR TITLE
fix: cron backups are not deleted when the cluster is deleted

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/robfig/cron/v3"
 
+	r "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/client"
@@ -322,114 +323,16 @@ func (h *handler) DeleteCluster(request *restful.Request, response *restful.Resp
 		return
 	}
 
-	// delete cronBackups before delete cluster
-	cronBackups, err := h.clusterOperator.ListCronBackups(request.Request.Context(), query.New())
-	if err != nil {
-		restplus.HandleInternalError(response, request, err)
-		return
-	}
-	for _, cronBackup := range cronBackups.Items {
-		if cronBackup.Spec.ClusterName == c.Name {
-			// delete cronBackup
-			if err = h.clusterOperator.DeleteCronBackup(request.Request.Context(), cronBackup.Name); err != nil {
-				restplus.HandleInternalError(response, request, err)
-				return
-			}
-		}
-	}
-
-	// delete backup before delete cluster
 	q := query.New()
 	q.LabelSelector = fmt.Sprintf("%s=%s", common.LabelClusterName, c.Name)
-	backups, err := h.clusterOperator.ListBackups(request.Request.Context(), q)
+	backups, err := h.clusterOperator.ListBackupEx(request.Request.Context(), q)
 	if err != nil {
 		restplus.HandleInternalError(response, request, err)
 		return
 	}
-	for _, backup := range backups.Items {
-		bp, err := h.clusterOperator.GetBackupPointEx(request.Request.Context(), c.Labels[common.LabelBackupPoint], "0")
-		if err != nil {
-			restplus.HandleInternalError(response, request, err)
-			return
-		}
-
-		if backup.PreferredNode != "" {
-			_, err = h.clusterOperator.GetNodeEx(request.Request.Context(), backup.PreferredNode, "0")
-			if err != nil {
-				restplus.HandleInternalError(response, request, err)
-				return
-			}
-		}
-
-		// create operation
-		op := &v1.Operation{}
-		op.Name = uuid.New().String()
-		op.Labels = make(map[string]string)
-		op.Labels[common.LabelOperationAction] = v1.OperationDeleteBackup
-		op.Labels[common.LabelTimeoutSeconds] = strconv.Itoa(v1.DefaultBackupTimeoutSec)
-		op.Labels[common.LabelClusterName] = c.Name
-		op.Labels[common.LabelBackupName] = backup.Name
-		op.Labels[common.LabelTopologyRegion] = c.Masters[0].Labels[common.LabelTopologyRegion]
-		op.Status.Status = v1.OperationStatusRunning
-
-		// Ensure that all backups are created before deleting the cluster
-		if backup.Status.ClusterBackupStatus == v1.ClusterBackupCreating {
-			restplus.HandlerErrorWithCustomCode(response, request, http.StatusExpectationFailed, 417, "", fmt.Errorf("backup is %s now, can't delete", backup.Status.ClusterBackupStatus))
-			return
-		}
-
-		steps := make([]v1.Step, 0)
-		var actBackup *k8s.ActBackup
-		meta := component.ExtraMetadata{
-			ClusterName: c.Name,
-		}
-		meta.Masters = append(meta.Masters, component.Node{ID: backup.PreferredNode})
-		ctx := component.WithExtraMetadata(context.TODO(), meta)
-
-		switch bp.StorageType {
-		case bs.S3Storage:
-			actBackup = &k8s.ActBackup{
-				StoreType:       bp.StorageType,
-				BackupFileName:  backup.Status.FileName,
-				AccessKeyID:     bp.S3Config.AccessKeyID,
-				AccessKeySecret: bp.S3Config.AccessKeySecret,
-				Bucket:          bp.S3Config.Bucket,
-				Endpoint:        bp.S3Config.Endpoint,
-			}
-		case bs.FSStorage:
-			actBackup = &k8s.ActBackup{
-				StoreType:          bp.StorageType,
-				BackupFileName:     backup.Status.FileName,
-				BackupPointRootDir: bp.FsConfig.BackupRootDir,
-			}
-		}
-
-		if err = actBackup.InitSteps(ctx); err != nil {
-			restplus.HandleInternalError(response, request, err)
-			return
-		}
-
-		actBackupStep := actBackup.GetStep(v1.ActionUninstall)
-		op.Steps = append(steps, actBackupStep...)
-		op, err = h.opOperator.CreateOperation(ctx, op)
-		if err != nil {
-			restplus.HandleInternalError(response, request, err)
-			return
-		}
-
-		// delivery the delete backup operation
-		go func() {
-			err = h.delivery.DeliverTaskOperation(ctx, op, &service.Options{DryRun: false})
-			if err != nil {
-				logger.Errorf("delivery task error", zap.Error(err))
-			}
-		}()
-
-		// delete backup in etcd
-		if err = h.clusterOperator.DeleteBackup(request.Request.Context(), backup.Name); err != nil {
-			restplus.HandleInternalError(response, request, err)
-			return
-		}
+	if backups.TotalCount > 0 {
+		restplus.HandleInternalError(response, request, fmt.Errorf("before deleting the cluster, please delete the cluster backup file first"))
+		return
 	}
 
 	op, err := h.parseOperationFromCluster(extraMeta, c, v1.ActionUninstall)
@@ -1227,7 +1130,8 @@ func (h *handler) CreateBackup(request *restful.Request, response *restful.Respo
 		return
 	}
 
-	backup.Name = fmt.Sprintf("%s-%s", backup.Name, clusterName)
+	randNum := r.String(6)
+	backup.Name = fmt.Sprintf("%s-%s-%s", c.Name, clusterName, randNum)
 	backup.Status.KubernetesVersion = c.KubernetesVersion
 	backup.Status.FileName = fmt.Sprintf("%s-%s", c.Name, backup.Name)
 	backup.BackupPointName = c.Labels[common.LabelBackupPoint]

--- a/pkg/controller/cronbackupcontroller/controller.go
+++ b/pkg/controller/cronbackupcontroller/controller.go
@@ -228,7 +228,7 @@ func (r *CronBackupReconciler) createBackup(log logger.Logging, cronBackup *v1.C
 		return err
 	}
 
-	randNum := rand.String(5)
+	randNum := rand.String(6)
 	backup.Name = fmt.Sprintf("%s-%s-%s", c.Name, cronBackup.Name, randNum)
 	b, err := r.BackupLister.Get(backup.Name)
 	if err != nil && !apimachineryErrors.IsNotFound(err) {

--- a/pkg/models/cluster/cluster.go
+++ b/pkg/models/cluster/cluster.go
@@ -407,6 +407,18 @@ func (c *clusterOperator) DeleteCronBackup(ctx context.Context, name string) err
 	return err
 }
 
+func (c *clusterOperator) DeleteCronBackupCollection(ctx context.Context, query *query.Query) error {
+	if _, err := c.cronBackupStorage.DeleteCollection(ctx, func(ctx context.Context, obj runtime.Object) error {
+		return nil
+	}, &metav1.DeleteOptions{}, &metainternalversion.ListOptions{
+		LabelSelector: query.GetLabelSelector(),
+		FieldSelector: query.GetFieldSelector(),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
 // dns 相关
 
 func (c *clusterOperator) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {

--- a/pkg/models/cluster/interface.go
+++ b/pkg/models/cluster/interface.go
@@ -199,6 +199,7 @@ type CronBackupWriter interface {
 	CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error)
 	UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error)
 	DeleteCronBackup(ctx context.Context, name string) error
+	DeleteCronBackupCollection(ctx context.Context, query *query.Query) error
 }
 
 type DNSReader interface {

--- a/pkg/models/cluster/mock/mock_cluster.go
+++ b/pkg/models/cluster/mock/mock_cluster.go
@@ -6,293 +6,39 @@ package mock_cluster
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	models "github.com/kubeclipper/kubeclipper/pkg/models"
 	query "github.com/kubeclipper/kubeclipper/pkg/query"
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	watch "k8s.io/apimachinery/pkg/watch"
-	reflect "reflect"
 )
 
-// MockOperatorReader is a mock of OperatorReader interface
+// MockOperatorReader is a mock of OperatorReader interface.
 type MockOperatorReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockOperatorReaderMockRecorder
 }
 
-// MockOperatorReaderMockRecorder is the mock recorder for MockOperatorReader
+// MockOperatorReaderMockRecorder is the mock recorder for MockOperatorReader.
 type MockOperatorReaderMockRecorder struct {
 	mock *MockOperatorReader
 }
 
-// NewMockOperatorReader creates a new mock instance
+// NewMockOperatorReader creates a new mock instance.
 func NewMockOperatorReader(ctrl *gomock.Controller) *MockOperatorReader {
 	mock := &MockOperatorReader{ctrl: ctrl}
 	mock.recorder = &MockOperatorReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOperatorReader) EXPECT() *MockOperatorReaderMockRecorder {
 	return m.recorder
 }
 
-// ListClusters mocks base method
-func (m *MockOperatorReader) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
-	ret0, _ := ret[0].(*v1.ClusterList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusters indicates an expected call of ListClusters
-func (mr *MockOperatorReaderMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockOperatorReader)(nil).ListClusters), ctx, query)
-}
-
-// WatchClusters mocks base method
-func (m *MockOperatorReader) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchClusters indicates an expected call of WatchClusters
-func (mr *MockOperatorReaderMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockOperatorReader)(nil).WatchClusters), ctx, query)
-}
-
-// GetCluster mocks base method
-func (m *MockOperatorReader) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCluster indicates an expected call of GetCluster
-func (mr *MockOperatorReaderMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperatorReader)(nil).GetCluster), ctx, name)
-}
-
-// GetClusterEx mocks base method
-func (m *MockOperatorReader) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterEx indicates an expected call of GetClusterEx
-func (mr *MockOperatorReaderMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).GetClusterEx), ctx, name, resourceVersion)
-}
-
-// ListClusterEx mocks base method
-func (m *MockOperatorReader) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusterEx indicates an expected call of ListClusterEx
-func (mr *MockOperatorReaderMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).ListClusterEx), ctx, query)
-}
-
-// ListRegions mocks base method
-func (m *MockOperatorReader) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
-	ret0, _ := ret[0].(*v1.RegionList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegions indicates an expected call of ListRegions
-func (mr *MockOperatorReaderMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperatorReader)(nil).ListRegions), ctx, query)
-}
-
-// GetRegion mocks base method
-func (m *MockOperatorReader) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegion indicates an expected call of GetRegion
-func (mr *MockOperatorReaderMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperatorReader)(nil).GetRegion), ctx, name)
-}
-
-// WatchRegions mocks base method
-func (m *MockOperatorReader) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchRegions indicates an expected call of WatchRegions
-func (mr *MockOperatorReaderMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockOperatorReader)(nil).WatchRegions), ctx, query)
-}
-
-// ListRegionEx mocks base method
-func (m *MockOperatorReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegionEx indicates an expected call of ListRegionEx
-func (mr *MockOperatorReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRegionEx), ctx, query)
-}
-
-// GetRegionEx mocks base method
-func (m *MockOperatorReader) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegionEx indicates an expected call of GetRegionEx
-func (mr *MockOperatorReaderMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).GetRegionEx), ctx, name, resourceVersion)
-}
-
-// ListNodes mocks base method
-func (m *MockOperatorReader) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
-	ret0, _ := ret[0].(*v1.NodeList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodes indicates an expected call of ListNodes
-func (mr *MockOperatorReaderMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperatorReader)(nil).ListNodes), ctx, query)
-}
-
-// WatchNodes mocks base method
-func (m *MockOperatorReader) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchNodes indicates an expected call of WatchNodes
-func (mr *MockOperatorReaderMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperatorReader)(nil).WatchNodes), ctx, query)
-}
-
-// GetNode mocks base method
-func (m *MockOperatorReader) GetNode(ctx context.Context, name string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNode", ctx, name)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNode indicates an expected call of GetNode
-func (mr *MockOperatorReaderMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperatorReader)(nil).GetNode), ctx, name)
-}
-
-// GetNodeEx mocks base method
-func (m *MockOperatorReader) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNodeEx indicates an expected call of GetNodeEx
-func (mr *MockOperatorReaderMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperatorReader)(nil).GetNodeEx), ctx, name, resourceVersion)
-}
-
-// ListNodesEx mocks base method
-func (m *MockOperatorReader) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodesEx indicates an expected call of ListNodesEx
-func (mr *MockOperatorReaderMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperatorReader)(nil).ListNodesEx), ctx, query)
-}
-
-// ListBackups mocks base method
-func (m *MockOperatorReader) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackups indicates an expected call of ListBackups
-func (mr *MockOperatorReaderMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListBackups), ctx, query)
-}
-
-// WatchBackups mocks base method
-func (m *MockOperatorReader) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackups indicates an expected call of WatchBackups
-func (mr *MockOperatorReaderMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperatorReader)(nil).WatchBackups), ctx, query)
-}
-
-// GetBackup mocks base method
+// GetBackup mocks base method.
 func (m *MockOperatorReader) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
@@ -301,28 +47,13 @@ func (m *MockOperatorReader) GetBackup(ctx context.Context, cluster, name string
 	return ret0, ret1
 }
 
-// GetBackup indicates an expected call of GetBackup
+// GetBackup indicates an expected call of GetBackup.
 func (mr *MockOperatorReaderMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockOperatorReader)(nil).GetBackup), ctx, cluster, name)
 }
 
-// ListBackupEx mocks base method
-func (m *MockOperatorReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupEx indicates an expected call of ListBackupEx
-func (mr *MockOperatorReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupEx), ctx, query)
-}
-
-// GetBackupEx mocks base method
+// GetBackupEx mocks base method.
 func (m *MockOperatorReader) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
@@ -331,28 +62,13 @@ func (m *MockOperatorReader) GetBackupEx(ctx context.Context, cluster, name stri
 	return ret0, ret1
 }
 
-// GetBackupEx indicates an expected call of GetBackupEx
+// GetBackupEx indicates an expected call of GetBackupEx.
 func (mr *MockOperatorReaderMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupEx), ctx, cluster, name)
 }
 
-// ListBackupPoints mocks base method
-func (m *MockOperatorReader) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupPointList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPoints indicates an expected call of ListBackupPoints
-func (mr *MockOperatorReaderMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPoints), ctx, query)
-}
-
-// GetBackupPoint mocks base method
+// GetBackupPoint mocks base method.
 func (m *MockOperatorReader) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
@@ -361,43 +77,13 @@ func (m *MockOperatorReader) GetBackupPoint(ctx context.Context, name, resourceV
 	return ret0, ret1
 }
 
-// GetBackupPoint indicates an expected call of GetBackupPoint
+// GetBackupPoint indicates an expected call of GetBackupPoint.
 func (mr *MockOperatorReaderMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupPoint), ctx, name, resourceVersion)
 }
 
-// WatchBackupPoints mocks base method
-func (m *MockOperatorReader) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackupPoints indicates an expected call of WatchBackupPoints
-func (mr *MockOperatorReaderMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockOperatorReader)(nil).WatchBackupPoints), ctx, query)
-}
-
-// ListBackupPointEx mocks base method
-func (m *MockOperatorReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPointEx indicates an expected call of ListBackupPointEx
-func (mr *MockOperatorReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPointEx), ctx, query)
-}
-
-// GetBackupPointEx mocks base method
+// GetBackupPointEx mocks base method.
 func (m *MockOperatorReader) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
@@ -406,28 +92,43 @@ func (m *MockOperatorReader) GetBackupPointEx(ctx context.Context, name, resourc
 	return ret0, ret1
 }
 
-// GetBackupPointEx indicates an expected call of GetBackupPointEx
+// GetBackupPointEx indicates an expected call of GetBackupPointEx.
 func (mr *MockOperatorReaderMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockOperatorReader)(nil).GetBackupPointEx), ctx, name, resourceVersion)
 }
 
-// ListCronBackups mocks base method
-func (m *MockOperatorReader) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
+// GetCluster mocks base method.
+func (m *MockOperatorReader) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.CronBackupList)
+	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
+	ret0, _ := ret[0].(*v1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListCronBackups indicates an expected call of ListCronBackups
-func (mr *MockOperatorReaderMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
+// GetCluster indicates an expected call of GetCluster.
+func (mr *MockOperatorReaderMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackups), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperatorReader)(nil).GetCluster), ctx, name)
 }
 
-// GetCronBackup mocks base method
+// GetClusterEx mocks base method.
+func (m *MockOperatorReader) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterEx indicates an expected call of GetClusterEx.
+func (mr *MockOperatorReaderMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).GetClusterEx), ctx, name, resourceVersion)
+}
+
+// GetCronBackup mocks base method.
 func (m *MockOperatorReader) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
@@ -436,43 +137,13 @@ func (m *MockOperatorReader) GetCronBackup(ctx context.Context, name, resourceVe
 	return ret0, ret1
 }
 
-// GetCronBackup indicates an expected call of GetCronBackup
+// GetCronBackup indicates an expected call of GetCronBackup.
 func (mr *MockOperatorReaderMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockOperatorReader)(nil).GetCronBackup), ctx, name, resourceVersion)
 }
 
-// WatchCronBackups mocks base method
-func (m *MockOperatorReader) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchCronBackups indicates an expected call of WatchCronBackups
-func (mr *MockOperatorReaderMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockOperatorReader)(nil).WatchCronBackups), ctx, query)
-}
-
-// ListCronBackupEx mocks base method
-func (m *MockOperatorReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackupEx indicates an expected call of ListCronBackupEx
-func (mr *MockOperatorReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackupEx), ctx, query)
-}
-
-// GetCronBackupEx mocks base method
+// GetCronBackupEx mocks base method.
 func (m *MockOperatorReader) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
@@ -481,28 +152,13 @@ func (m *MockOperatorReader) GetCronBackupEx(ctx context.Context, name, resource
 	return ret0, ret1
 }
 
-// GetCronBackupEx indicates an expected call of GetCronBackupEx
+// GetCronBackupEx indicates an expected call of GetCronBackupEx.
 func (mr *MockOperatorReaderMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).GetCronBackupEx), ctx, name, resourceVersion)
 }
 
-// ListDomains mocks base method
-func (m *MockOperatorReader) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
-	ret0, _ := ret[0].(*v1.DomainList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomains indicates an expected call of ListDomains
-func (mr *MockOperatorReaderMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperatorReader)(nil).ListDomains), ctx, query)
-}
-
-// GetDomain mocks base method
+// GetDomain mocks base method.
 func (m *MockOperatorReader) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
@@ -511,43 +167,208 @@ func (m *MockOperatorReader) GetDomain(ctx context.Context, name string) (*v1.Do
 	return ret0, ret1
 }
 
-// GetDomain indicates an expected call of GetDomain
+// GetDomain indicates an expected call of GetDomain.
 func (mr *MockOperatorReaderMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockOperatorReader)(nil).GetDomain), ctx, name)
 }
 
-// WatchDomain mocks base method
-func (m *MockOperatorReader) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+// GetNode mocks base method.
+func (m *MockOperatorReader) GetNode(ctx context.Context, name string) (*v1.Node, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
+	ret := m.ctrl.Call(m, "GetNode", ctx, name)
+	ret0, _ := ret[0].(*v1.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchDomain indicates an expected call of WatchDomain
-func (mr *MockOperatorReaderMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+// GetNode indicates an expected call of GetNode.
+func (mr *MockOperatorReaderMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperatorReader)(nil).WatchDomain), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperatorReader)(nil).GetNode), ctx, name)
 }
 
-// ListRecordsEx mocks base method
-func (m *MockOperatorReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+// GetNodeEx mocks base method.
+func (m *MockOperatorReader) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
+	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeEx indicates an expected call of GetNodeEx.
+func (mr *MockOperatorReaderMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperatorReader)(nil).GetNodeEx), ctx, name, resourceVersion)
+}
+
+// GetRegion mocks base method.
+func (m *MockOperatorReader) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegion indicates an expected call of GetRegion.
+func (mr *MockOperatorReaderMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperatorReader)(nil).GetRegion), ctx, name)
+}
+
+// GetRegionEx mocks base method.
+func (m *MockOperatorReader) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegionEx indicates an expected call of GetRegionEx.
+func (mr *MockOperatorReaderMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).GetRegionEx), ctx, name, resourceVersion)
+}
+
+// ListBackupEx mocks base method.
+func (m *MockOperatorReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
 	ret0, _ := ret[0].(*models.PageableResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListRecordsEx indicates an expected call of ListRecordsEx
-func (mr *MockOperatorReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+// ListBackupEx indicates an expected call of ListBackupEx.
+func (mr *MockOperatorReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupEx), ctx, query)
 }
 
-// ListDomainsEx mocks base method
+// ListBackupPointEx mocks base method.
+func (m *MockOperatorReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPointEx indicates an expected call of ListBackupPointEx.
+func (mr *MockOperatorReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPointEx), ctx, query)
+}
+
+// ListBackupPoints mocks base method.
+func (m *MockOperatorReader) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupPointList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPoints indicates an expected call of ListBackupPoints.
+func (mr *MockOperatorReaderMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperatorReader)(nil).ListBackupPoints), ctx, query)
+}
+
+// ListBackups mocks base method.
+func (m *MockOperatorReader) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackups indicates an expected call of ListBackups.
+func (mr *MockOperatorReaderMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListBackups), ctx, query)
+}
+
+// ListClusterEx mocks base method.
+func (m *MockOperatorReader) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusterEx indicates an expected call of ListClusterEx.
+func (mr *MockOperatorReaderMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperatorReader)(nil).ListClusterEx), ctx, query)
+}
+
+// ListClusters mocks base method.
+func (m *MockOperatorReader) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
+	ret0, _ := ret[0].(*v1.ClusterList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusters indicates an expected call of ListClusters.
+func (mr *MockOperatorReaderMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockOperatorReader)(nil).ListClusters), ctx, query)
+}
+
+// ListCronBackupEx mocks base method.
+func (m *MockOperatorReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackupEx indicates an expected call of ListCronBackupEx.
+func (mr *MockOperatorReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackupEx), ctx, query)
+}
+
+// ListCronBackups mocks base method.
+func (m *MockOperatorReader) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.CronBackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackups indicates an expected call of ListCronBackups.
+func (mr *MockOperatorReaderMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperatorReader)(nil).ListCronBackups), ctx, query)
+}
+
+// ListDomains mocks base method.
+func (m *MockOperatorReader) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
+	ret0, _ := ret[0].(*v1.DomainList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomains indicates an expected call of ListDomains.
+func (mr *MockOperatorReaderMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperatorReader)(nil).ListDomains), ctx, query)
+}
+
+// ListDomainsEx mocks base method.
 func (m *MockOperatorReader) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
@@ -556,153 +377,216 @@ func (m *MockOperatorReader) ListDomainsEx(ctx context.Context, query *query.Que
 	return ret0, ret1
 }
 
-// ListDomainsEx indicates an expected call of ListDomainsEx
+// ListDomainsEx indicates an expected call of ListDomainsEx.
 func (mr *MockOperatorReaderMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockOperatorReader)(nil).ListDomainsEx), ctx, query)
 }
 
-// MockOperatorWriter is a mock of OperatorWriter interface
+// ListNodes mocks base method.
+func (m *MockOperatorReader) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
+	ret0, _ := ret[0].(*v1.NodeList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodes indicates an expected call of ListNodes.
+func (mr *MockOperatorReaderMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperatorReader)(nil).ListNodes), ctx, query)
+}
+
+// ListNodesEx mocks base method.
+func (m *MockOperatorReader) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodesEx indicates an expected call of ListNodesEx.
+func (mr *MockOperatorReaderMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperatorReader)(nil).ListNodesEx), ctx, query)
+}
+
+// ListRecordsEx mocks base method.
+func (m *MockOperatorReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRecordsEx indicates an expected call of ListRecordsEx.
+func (mr *MockOperatorReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
+}
+
+// ListRegionEx mocks base method.
+func (m *MockOperatorReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegionEx indicates an expected call of ListRegionEx.
+func (mr *MockOperatorReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperatorReader)(nil).ListRegionEx), ctx, query)
+}
+
+// ListRegions mocks base method.
+func (m *MockOperatorReader) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
+	ret0, _ := ret[0].(*v1.RegionList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegions indicates an expected call of ListRegions.
+func (mr *MockOperatorReaderMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperatorReader)(nil).ListRegions), ctx, query)
+}
+
+// WatchBackupPoints mocks base method.
+func (m *MockOperatorReader) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackupPoints indicates an expected call of WatchBackupPoints.
+func (mr *MockOperatorReaderMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockOperatorReader)(nil).WatchBackupPoints), ctx, query)
+}
+
+// WatchBackups mocks base method.
+func (m *MockOperatorReader) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackups indicates an expected call of WatchBackups.
+func (mr *MockOperatorReaderMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperatorReader)(nil).WatchBackups), ctx, query)
+}
+
+// WatchClusters mocks base method.
+func (m *MockOperatorReader) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchClusters indicates an expected call of WatchClusters.
+func (mr *MockOperatorReaderMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockOperatorReader)(nil).WatchClusters), ctx, query)
+}
+
+// WatchCronBackups mocks base method.
+func (m *MockOperatorReader) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchCronBackups indicates an expected call of WatchCronBackups.
+func (mr *MockOperatorReaderMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockOperatorReader)(nil).WatchCronBackups), ctx, query)
+}
+
+// WatchDomain mocks base method.
+func (m *MockOperatorReader) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchDomain indicates an expected call of WatchDomain.
+func (mr *MockOperatorReaderMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperatorReader)(nil).WatchDomain), ctx, query)
+}
+
+// WatchNodes mocks base method.
+func (m *MockOperatorReader) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchNodes indicates an expected call of WatchNodes.
+func (mr *MockOperatorReaderMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperatorReader)(nil).WatchNodes), ctx, query)
+}
+
+// WatchRegions mocks base method.
+func (m *MockOperatorReader) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchRegions indicates an expected call of WatchRegions.
+func (mr *MockOperatorReaderMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockOperatorReader)(nil).WatchRegions), ctx, query)
+}
+
+// MockOperatorWriter is a mock of OperatorWriter interface.
 type MockOperatorWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockOperatorWriterMockRecorder
 }
 
-// MockOperatorWriterMockRecorder is the mock recorder for MockOperatorWriter
+// MockOperatorWriterMockRecorder is the mock recorder for MockOperatorWriter.
 type MockOperatorWriterMockRecorder struct {
 	mock *MockOperatorWriter
 }
 
-// NewMockOperatorWriter creates a new mock instance
+// NewMockOperatorWriter creates a new mock instance.
 func NewMockOperatorWriter(ctrl *gomock.Controller) *MockOperatorWriter {
 	mock := &MockOperatorWriter{ctrl: ctrl}
 	mock.recorder = &MockOperatorWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOperatorWriter) EXPECT() *MockOperatorWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateCluster mocks base method
-func (m *MockOperatorWriter) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCluster indicates an expected call of CreateCluster
-func (mr *MockOperatorWriterMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockOperatorWriter)(nil).CreateCluster), ctx, cluster)
-}
-
-// UpdateCluster mocks base method
-func (m *MockOperatorWriter) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateCluster indicates an expected call of UpdateCluster
-func (mr *MockOperatorWriterMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateCluster), ctx, cluster)
-}
-
-// DeleteCluster mocks base method
-func (m *MockOperatorWriter) DeleteCluster(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCluster indicates an expected call of DeleteCluster
-func (mr *MockOperatorWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCluster), ctx, name)
-}
-
-// CreateRegion mocks base method
-func (m *MockOperatorWriter) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateRegion indicates an expected call of CreateRegion
-func (mr *MockOperatorWriterMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperatorWriter)(nil).CreateRegion), ctx, region)
-}
-
-// DeleteRegion mocks base method
-func (m *MockOperatorWriter) DeleteRegion(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRegion indicates an expected call of DeleteRegion
-func (mr *MockOperatorWriterMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteRegion), ctx, name)
-}
-
-// UpdateNode mocks base method
-func (m *MockOperatorWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateNode indicates an expected call of UpdateNode
-func (mr *MockOperatorWriterMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateNode), ctx, node)
-}
-
-// CreateNode mocks base method
-func (m *MockOperatorWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateNode indicates an expected call of CreateNode
-func (mr *MockOperatorWriterMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperatorWriter)(nil).CreateNode), ctx, node)
-}
-
-// DeleteNode mocks base method
-func (m *MockOperatorWriter) DeleteNode(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteNode indicates an expected call of DeleteNode
-func (mr *MockOperatorWriterMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteNode), ctx, name)
-}
-
-// CreateBackup mocks base method
+// CreateBackup mocks base method.
 func (m *MockOperatorWriter) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
@@ -711,42 +595,13 @@ func (m *MockOperatorWriter) CreateBackup(ctc context.Context, backup *v1.Backup
 	return ret0, ret1
 }
 
-// CreateBackup indicates an expected call of CreateBackup
+// CreateBackup indicates an expected call of CreateBackup.
 func (mr *MockOperatorWriterMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockOperatorWriter)(nil).CreateBackup), ctc, backup)
 }
 
-// UpdateBackup mocks base method
-func (m *MockOperatorWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateBackup indicates an expected call of UpdateBackup
-func (mr *MockOperatorWriterMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackup), ctx, backup)
-}
-
-// DeleteBackup mocks base method
-func (m *MockOperatorWriter) DeleteBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackup indicates an expected call of DeleteBackup
-func (mr *MockOperatorWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackup), ctx, name)
-}
-
-// CreateBackupPoint mocks base method
+// CreateBackupPoint mocks base method.
 func (m *MockOperatorWriter) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
@@ -755,42 +610,28 @@ func (m *MockOperatorWriter) CreateBackupPoint(ctx context.Context, backupPoint 
 	return ret0, ret1
 }
 
-// CreateBackupPoint indicates an expected call of CreateBackupPoint
+// CreateBackupPoint indicates an expected call of CreateBackupPoint.
 func (mr *MockOperatorWriterMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).CreateBackupPoint), ctx, backupPoint)
 }
 
-// UpdateBackupPoint mocks base method
-func (m *MockOperatorWriter) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+// CreateCluster mocks base method.
+func (m *MockOperatorWriter) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
-	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
+	ret0, _ := ret[0].(*v1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateBackupPoint indicates an expected call of UpdateBackupPoint
-func (mr *MockOperatorWriterMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
+// CreateCluster indicates an expected call of CreateCluster.
+func (mr *MockOperatorWriterMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackupPoint), ctx, backupPoint)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockOperatorWriter)(nil).CreateCluster), ctx, cluster)
 }
 
-// DeleteBackupPoint mocks base method
-func (m *MockOperatorWriter) DeleteBackupPoint(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackupPoint indicates an expected call of DeleteBackupPoint
-func (mr *MockOperatorWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackupPoint), ctx, name)
-}
-
-// CreateCronBackup mocks base method
+// CreateCronBackup mocks base method.
 func (m *MockOperatorWriter) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
@@ -799,42 +640,13 @@ func (m *MockOperatorWriter) CreateCronBackup(ctx context.Context, cronBackup *v
 	return ret0, ret1
 }
 
-// CreateCronBackup indicates an expected call of CreateCronBackup
+// CreateCronBackup indicates an expected call of CreateCronBackup.
 func (mr *MockOperatorWriterMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).CreateCronBackup), ctx, cronBackup)
 }
 
-// UpdateCronBackup mocks base method
-func (m *MockOperatorWriter) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateCronBackup indicates an expected call of UpdateCronBackup
-func (mr *MockOperatorWriterMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateCronBackup), ctx, cronBackup)
-}
-
-// DeleteCronBackup mocks base method
-func (m *MockOperatorWriter) DeleteCronBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCronBackup indicates an expected call of DeleteCronBackup
-func (mr *MockOperatorWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCronBackup), ctx, name)
-}
-
-// CreateDomain mocks base method
+// CreateDomain mocks base method.
 func (m *MockOperatorWriter) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
@@ -843,13 +655,215 @@ func (m *MockOperatorWriter) CreateDomain(ctc context.Context, domain *v1.Domain
 	return ret0, ret1
 }
 
-// CreateDomain indicates an expected call of CreateDomain
+// CreateDomain indicates an expected call of CreateDomain.
 func (mr *MockOperatorWriterMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockOperatorWriter)(nil).CreateDomain), ctc, domain)
 }
 
-// UpdateDomain mocks base method
+// CreateNode mocks base method.
+func (m *MockOperatorWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNode indicates an expected call of CreateNode.
+func (mr *MockOperatorWriterMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperatorWriter)(nil).CreateNode), ctx, node)
+}
+
+// CreateRegion mocks base method.
+func (m *MockOperatorWriter) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRegion indicates an expected call of CreateRegion.
+func (mr *MockOperatorWriterMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperatorWriter)(nil).CreateRegion), ctx, region)
+}
+
+// DeleteBackup mocks base method.
+func (m *MockOperatorWriter) DeleteBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackup indicates an expected call of DeleteBackup.
+func (mr *MockOperatorWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackup), ctx, name)
+}
+
+// DeleteBackupPoint mocks base method.
+func (m *MockOperatorWriter) DeleteBackupPoint(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackupPoint indicates an expected call of DeleteBackupPoint.
+func (mr *MockOperatorWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteBackupPoint), ctx, name)
+}
+
+// DeleteCluster mocks base method.
+func (m *MockOperatorWriter) DeleteCluster(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCluster indicates an expected call of DeleteCluster.
+func (mr *MockOperatorWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCluster), ctx, name)
+}
+
+// DeleteCronBackup mocks base method.
+func (m *MockOperatorWriter) DeleteCronBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackup indicates an expected call of DeleteCronBackup.
+func (mr *MockOperatorWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCronBackup), ctx, name)
+}
+
+// DeleteCronBackupCollection mocks base method.
+func (m *MockOperatorWriter) DeleteCronBackupCollection(ctx context.Context, query *query.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackupCollection", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackupCollection indicates an expected call of DeleteCronBackupCollection.
+func (mr *MockOperatorWriterMockRecorder) DeleteCronBackupCollection(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackupCollection", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteCronBackupCollection), ctx, query)
+}
+
+// DeleteDomain mocks base method.
+func (m *MockOperatorWriter) DeleteDomain(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDomain indicates an expected call of DeleteDomain.
+func (mr *MockOperatorWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteDomain), ctx, name)
+}
+
+// DeleteNode mocks base method.
+func (m *MockOperatorWriter) DeleteNode(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNode indicates an expected call of DeleteNode.
+func (mr *MockOperatorWriterMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteNode), ctx, name)
+}
+
+// DeleteRegion mocks base method.
+func (m *MockOperatorWriter) DeleteRegion(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRegion indicates an expected call of DeleteRegion.
+func (mr *MockOperatorWriterMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteRegion), ctx, name)
+}
+
+// UpdateBackup mocks base method.
+func (m *MockOperatorWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateBackup indicates an expected call of UpdateBackup.
+func (mr *MockOperatorWriterMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackup), ctx, backup)
+}
+
+// UpdateBackupPoint mocks base method.
+func (m *MockOperatorWriter) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateBackupPoint indicates an expected call of UpdateBackupPoint.
+func (mr *MockOperatorWriterMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateBackupPoint), ctx, backupPoint)
+}
+
+// UpdateCluster mocks base method.
+func (m *MockOperatorWriter) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCluster indicates an expected call of UpdateCluster.
+func (mr *MockOperatorWriterMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateCluster), ctx, cluster)
+}
+
+// UpdateCronBackup mocks base method.
+func (m *MockOperatorWriter) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCronBackup indicates an expected call of UpdateCronBackup.
+func (mr *MockOperatorWriterMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateCronBackup), ctx, cronBackup)
+}
+
+// UpdateDomain mocks base method.
 func (m *MockOperatorWriter) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
@@ -858,349 +872,14 @@ func (m *MockOperatorWriter) UpdateDomain(ctx context.Context, domain *v1.Domain
 	return ret0, ret1
 }
 
-// UpdateDomain indicates an expected call of UpdateDomain
+// UpdateDomain indicates an expected call of UpdateDomain.
 func (mr *MockOperatorWriterMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateDomain), ctx, domain)
 }
 
-// DeleteDomain mocks base method
-func (m *MockOperatorWriter) DeleteDomain(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteDomain indicates an expected call of DeleteDomain
-func (mr *MockOperatorWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperatorWriter)(nil).DeleteDomain), ctx, name)
-}
-
-// MockOperator is a mock of Operator interface
-type MockOperator struct {
-	ctrl     *gomock.Controller
-	recorder *MockOperatorMockRecorder
-}
-
-// MockOperatorMockRecorder is the mock recorder for MockOperator
-type MockOperatorMockRecorder struct {
-	mock *MockOperator
-}
-
-// NewMockOperator creates a new mock instance
-func NewMockOperator(ctrl *gomock.Controller) *MockOperator {
-	mock := &MockOperator{ctrl: ctrl}
-	mock.recorder = &MockOperatorMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
-	return m.recorder
-}
-
-// ListClusters mocks base method
-func (m *MockOperator) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
-	ret0, _ := ret[0].(*v1.ClusterList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusters indicates an expected call of ListClusters
-func (mr *MockOperatorMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockOperator)(nil).ListClusters), ctx, query)
-}
-
-// WatchClusters mocks base method
-func (m *MockOperator) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchClusters indicates an expected call of WatchClusters
-func (mr *MockOperatorMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockOperator)(nil).WatchClusters), ctx, query)
-}
-
-// GetCluster mocks base method
-func (m *MockOperator) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCluster indicates an expected call of GetCluster
-func (mr *MockOperatorMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperator)(nil).GetCluster), ctx, name)
-}
-
-// GetClusterEx mocks base method
-func (m *MockOperator) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetClusterEx indicates an expected call of GetClusterEx
-func (mr *MockOperatorMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperator)(nil).GetClusterEx), ctx, name, resourceVersion)
-}
-
-// ListClusterEx mocks base method
-func (m *MockOperator) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListClusterEx indicates an expected call of ListClusterEx
-func (mr *MockOperatorMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperator)(nil).ListClusterEx), ctx, query)
-}
-
-// CreateCluster mocks base method
-func (m *MockOperator) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateCluster indicates an expected call of CreateCluster
-func (mr *MockOperatorMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockOperator)(nil).CreateCluster), ctx, cluster)
-}
-
-// UpdateCluster mocks base method
-func (m *MockOperator) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
-	ret0, _ := ret[0].(*v1.Cluster)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateCluster indicates an expected call of UpdateCluster
-func (mr *MockOperatorMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOperator)(nil).UpdateCluster), ctx, cluster)
-}
-
-// DeleteCluster mocks base method
-func (m *MockOperator) DeleteCluster(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCluster indicates an expected call of DeleteCluster
-func (mr *MockOperatorMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperator)(nil).DeleteCluster), ctx, name)
-}
-
-// ListRegions mocks base method
-func (m *MockOperator) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
-	ret0, _ := ret[0].(*v1.RegionList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegions indicates an expected call of ListRegions
-func (mr *MockOperatorMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperator)(nil).ListRegions), ctx, query)
-}
-
-// GetRegion mocks base method
-func (m *MockOperator) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegion indicates an expected call of GetRegion
-func (mr *MockOperatorMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperator)(nil).GetRegion), ctx, name)
-}
-
-// WatchRegions mocks base method
-func (m *MockOperator) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchRegions indicates an expected call of WatchRegions
-func (mr *MockOperatorMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockOperator)(nil).WatchRegions), ctx, query)
-}
-
-// ListRegionEx mocks base method
-func (m *MockOperator) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegionEx indicates an expected call of ListRegionEx
-func (mr *MockOperatorMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperator)(nil).ListRegionEx), ctx, query)
-}
-
-// GetRegionEx mocks base method
-func (m *MockOperator) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRegionEx indicates an expected call of GetRegionEx
-func (mr *MockOperatorMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperator)(nil).GetRegionEx), ctx, name, resourceVersion)
-}
-
-// CreateRegion mocks base method
-func (m *MockOperator) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
-	ret0, _ := ret[0].(*v1.Region)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateRegion indicates an expected call of CreateRegion
-func (mr *MockOperatorMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperator)(nil).CreateRegion), ctx, region)
-}
-
-// DeleteRegion mocks base method
-func (m *MockOperator) DeleteRegion(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRegion indicates an expected call of DeleteRegion
-func (mr *MockOperatorMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperator)(nil).DeleteRegion), ctx, name)
-}
-
-// ListNodes mocks base method
-func (m *MockOperator) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
-	ret0, _ := ret[0].(*v1.NodeList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodes indicates an expected call of ListNodes
-func (mr *MockOperatorMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperator)(nil).ListNodes), ctx, query)
-}
-
-// WatchNodes mocks base method
-func (m *MockOperator) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchNodes indicates an expected call of WatchNodes
-func (mr *MockOperatorMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperator)(nil).WatchNodes), ctx, query)
-}
-
-// GetNode mocks base method
-func (m *MockOperator) GetNode(ctx context.Context, name string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNode", ctx, name)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNode indicates an expected call of GetNode
-func (mr *MockOperatorMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperator)(nil).GetNode), ctx, name)
-}
-
-// GetNodeEx mocks base method
-func (m *MockOperator) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetNodeEx indicates an expected call of GetNodeEx
-func (mr *MockOperatorMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperator)(nil).GetNodeEx), ctx, name, resourceVersion)
-}
-
-// ListNodesEx mocks base method
-func (m *MockOperator) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodesEx indicates an expected call of ListNodesEx
-func (mr *MockOperatorMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperator)(nil).ListNodesEx), ctx, query)
-}
-
-// UpdateNode mocks base method
-func (m *MockOperator) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+// UpdateNode mocks base method.
+func (m *MockOperatorWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
 	ret0, _ := ret[0].(*v1.Node)
@@ -1208,117 +887,36 @@ func (m *MockOperator) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node,
 	return ret0, ret1
 }
 
-// UpdateNode indicates an expected call of UpdateNode
-func (mr *MockOperatorMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
+// UpdateNode indicates an expected call of UpdateNode.
+func (mr *MockOperatorWriterMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockOperator)(nil).UpdateNode), ctx, node)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockOperatorWriter)(nil).UpdateNode), ctx, node)
 }
 
-// CreateNode mocks base method
-func (m *MockOperator) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+// MockOperator is a mock of Operator interface.
+type MockOperator struct {
+	ctrl     *gomock.Controller
+	recorder *MockOperatorMockRecorder
 }
 
-// CreateNode indicates an expected call of CreateNode
-func (mr *MockOperatorMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperator)(nil).CreateNode), ctx, node)
+// MockOperatorMockRecorder is the mock recorder for MockOperator.
+type MockOperatorMockRecorder struct {
+	mock *MockOperator
 }
 
-// DeleteNode mocks base method
-func (m *MockOperator) DeleteNode(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
+// NewMockOperator creates a new mock instance.
+func NewMockOperator(ctrl *gomock.Controller) *MockOperator {
+	mock := &MockOperator{ctrl: ctrl}
+	mock.recorder = &MockOperatorMockRecorder{mock}
+	return mock
 }
 
-// DeleteNode indicates an expected call of DeleteNode
-func (mr *MockOperatorMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperator)(nil).DeleteNode), ctx, name)
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOperator) EXPECT() *MockOperatorMockRecorder {
+	return m.recorder
 }
 
-// ListBackups mocks base method
-func (m *MockOperator) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackups indicates an expected call of ListBackups
-func (mr *MockOperatorMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperator)(nil).ListBackups), ctx, query)
-}
-
-// WatchBackups mocks base method
-func (m *MockOperator) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackups indicates an expected call of WatchBackups
-func (mr *MockOperatorMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperator)(nil).WatchBackups), ctx, query)
-}
-
-// GetBackup mocks base method
-func (m *MockOperator) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackup indicates an expected call of GetBackup
-func (mr *MockOperatorMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockOperator)(nil).GetBackup), ctx, cluster, name)
-}
-
-// ListBackupEx mocks base method
-func (m *MockOperator) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupEx indicates an expected call of ListBackupEx
-func (mr *MockOperatorMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperator)(nil).ListBackupEx), ctx, query)
-}
-
-// GetBackupEx mocks base method
-func (m *MockOperator) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupEx indicates an expected call of GetBackupEx
-func (mr *MockOperatorMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockOperator)(nil).GetBackupEx), ctx, cluster, name)
-}
-
-// CreateBackup mocks base method
+// CreateBackup mocks base method.
 func (m *MockOperator) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
@@ -1327,117 +925,13 @@ func (m *MockOperator) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1
 	return ret0, ret1
 }
 
-// CreateBackup indicates an expected call of CreateBackup
+// CreateBackup indicates an expected call of CreateBackup.
 func (mr *MockOperatorMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockOperator)(nil).CreateBackup), ctc, backup)
 }
 
-// UpdateBackup mocks base method
-func (m *MockOperator) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
-	ret0, _ := ret[0].(*v1.Backup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateBackup indicates an expected call of UpdateBackup
-func (mr *MockOperatorMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperator)(nil).UpdateBackup), ctx, backup)
-}
-
-// DeleteBackup mocks base method
-func (m *MockOperator) DeleteBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackup indicates an expected call of DeleteBackup
-func (mr *MockOperatorMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperator)(nil).DeleteBackup), ctx, name)
-}
-
-// ListBackupPoints mocks base method
-func (m *MockOperator) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupPointList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPoints indicates an expected call of ListBackupPoints
-func (mr *MockOperatorMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperator)(nil).ListBackupPoints), ctx, query)
-}
-
-// GetBackupPoint mocks base method
-func (m *MockOperator) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupPoint indicates an expected call of GetBackupPoint
-func (mr *MockOperatorMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockOperator)(nil).GetBackupPoint), ctx, name, resourceVersion)
-}
-
-// WatchBackupPoints mocks base method
-func (m *MockOperator) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackupPoints indicates an expected call of WatchBackupPoints
-func (mr *MockOperatorMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockOperator)(nil).WatchBackupPoints), ctx, query)
-}
-
-// ListBackupPointEx mocks base method
-func (m *MockOperator) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPointEx indicates an expected call of ListBackupPointEx
-func (mr *MockOperatorMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperator)(nil).ListBackupPointEx), ctx, query)
-}
-
-// GetBackupPointEx mocks base method
-func (m *MockOperator) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.BackupPoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBackupPointEx indicates an expected call of GetBackupPointEx
-func (mr *MockOperatorMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockOperator)(nil).GetBackupPointEx), ctx, name, resourceVersion)
-}
-
-// CreateBackupPoint mocks base method
+// CreateBackupPoint mocks base method.
 func (m *MockOperator) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
@@ -1446,117 +940,28 @@ func (m *MockOperator) CreateBackupPoint(ctx context.Context, backupPoint *v1.Ba
 	return ret0, ret1
 }
 
-// CreateBackupPoint indicates an expected call of CreateBackupPoint
+// CreateBackupPoint indicates an expected call of CreateBackupPoint.
 func (mr *MockOperatorMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockOperator)(nil).CreateBackupPoint), ctx, backupPoint)
 }
 
-// UpdateBackupPoint mocks base method
-func (m *MockOperator) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+// CreateCluster mocks base method.
+func (m *MockOperator) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
-	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
+	ret0, _ := ret[0].(*v1.Cluster)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateBackupPoint indicates an expected call of UpdateBackupPoint
-func (mr *MockOperatorMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
+// CreateCluster indicates an expected call of CreateCluster.
+func (mr *MockOperatorMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperator)(nil).UpdateBackupPoint), ctx, backupPoint)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockOperator)(nil).CreateCluster), ctx, cluster)
 }
 
-// DeleteBackupPoint mocks base method
-func (m *MockOperator) DeleteBackupPoint(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackupPoint indicates an expected call of DeleteBackupPoint
-func (mr *MockOperatorMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperator)(nil).DeleteBackupPoint), ctx, name)
-}
-
-// ListCronBackups mocks base method
-func (m *MockOperator) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.CronBackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackups indicates an expected call of ListCronBackups
-func (mr *MockOperatorMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperator)(nil).ListCronBackups), ctx, query)
-}
-
-// GetCronBackup mocks base method
-func (m *MockOperator) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCronBackup indicates an expected call of GetCronBackup
-func (mr *MockOperatorMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockOperator)(nil).GetCronBackup), ctx, name, resourceVersion)
-}
-
-// WatchCronBackups mocks base method
-func (m *MockOperator) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchCronBackups indicates an expected call of WatchCronBackups
-func (mr *MockOperatorMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockOperator)(nil).WatchCronBackups), ctx, query)
-}
-
-// ListCronBackupEx mocks base method
-func (m *MockOperator) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackupEx indicates an expected call of ListCronBackupEx
-func (mr *MockOperatorMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperator)(nil).ListCronBackupEx), ctx, query)
-}
-
-// GetCronBackupEx mocks base method
-func (m *MockOperator) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCronBackupEx indicates an expected call of GetCronBackupEx
-func (mr *MockOperatorMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockOperator)(nil).GetCronBackupEx), ctx, name, resourceVersion)
-}
-
-// CreateCronBackup mocks base method
+// CreateCronBackup mocks base method.
 func (m *MockOperator) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
@@ -1565,117 +970,13 @@ func (m *MockOperator) CreateCronBackup(ctx context.Context, cronBackup *v1.Cron
 	return ret0, ret1
 }
 
-// CreateCronBackup indicates an expected call of CreateCronBackup
+// CreateCronBackup indicates an expected call of CreateCronBackup.
 func (mr *MockOperatorMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockOperator)(nil).CreateCronBackup), ctx, cronBackup)
 }
 
-// UpdateCronBackup mocks base method
-func (m *MockOperator) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
-	ret0, _ := ret[0].(*v1.CronBackup)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateCronBackup indicates an expected call of UpdateCronBackup
-func (mr *MockOperatorMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperator)(nil).UpdateCronBackup), ctx, cronBackup)
-}
-
-// DeleteCronBackup mocks base method
-func (m *MockOperator) DeleteCronBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCronBackup indicates an expected call of DeleteCronBackup
-func (mr *MockOperatorMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperator)(nil).DeleteCronBackup), ctx, name)
-}
-
-// ListDomains mocks base method
-func (m *MockOperator) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
-	ret0, _ := ret[0].(*v1.DomainList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomains indicates an expected call of ListDomains
-func (mr *MockOperatorMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperator)(nil).ListDomains), ctx, query)
-}
-
-// GetDomain mocks base method
-func (m *MockOperator) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
-	ret0, _ := ret[0].(*v1.Domain)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDomain indicates an expected call of GetDomain
-func (mr *MockOperatorMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockOperator)(nil).GetDomain), ctx, name)
-}
-
-// WatchDomain mocks base method
-func (m *MockOperator) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchDomain indicates an expected call of WatchDomain
-func (mr *MockOperatorMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperator)(nil).WatchDomain), ctx, query)
-}
-
-// ListRecordsEx mocks base method
-func (m *MockOperator) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecordsEx indicates an expected call of ListRecordsEx
-func (mr *MockOperatorMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperator)(nil).ListRecordsEx), ctx, name, subdomain, query)
-}
-
-// ListDomainsEx mocks base method
-func (m *MockOperator) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomainsEx indicates an expected call of ListDomainsEx
-func (mr *MockOperatorMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockOperator)(nil).ListDomainsEx), ctx, query)
-}
-
-// CreateDomain mocks base method
+// CreateDomain mocks base method.
 func (m *MockOperator) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
@@ -1684,117 +985,43 @@ func (m *MockOperator) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1
 	return ret0, ret1
 }
 
-// CreateDomain indicates an expected call of CreateDomain
+// CreateDomain indicates an expected call of CreateDomain.
 func (mr *MockOperatorMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockOperator)(nil).CreateDomain), ctc, domain)
 }
 
-// UpdateDomain mocks base method
-func (m *MockOperator) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
+// CreateNode mocks base method.
+func (m *MockOperator) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
-	ret0, _ := ret[0].(*v1.Domain)
+	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
+	ret0, _ := ret[0].(*v1.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateDomain indicates an expected call of UpdateDomain
-func (mr *MockOperatorMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
+// CreateNode indicates an expected call of CreateNode.
+func (mr *MockOperatorMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockOperator)(nil).UpdateDomain), ctx, domain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockOperator)(nil).CreateNode), ctx, node)
 }
 
-// DeleteDomain mocks base method
-func (m *MockOperator) DeleteDomain(ctx context.Context, name string) error {
+// CreateRegion mocks base method.
+func (m *MockOperator) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteDomain indicates an expected call of DeleteDomain
-func (mr *MockOperatorMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperator)(nil).DeleteDomain), ctx, name)
-}
-
-// ListTemplates mocks base method
-func (m *MockOperator) ListTemplates(ctx context.Context, query *query.Query) (*v1.TemplateList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTemplates", ctx, query)
-	ret0, _ := ret[0].(*v1.TemplateList)
+	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
+	ret0, _ := ret[0].(*v1.Region)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListTemplates indicates an expected call of ListTemplates
-func (mr *MockOperatorMockRecorder) ListTemplates(ctx, query interface{}) *gomock.Call {
+// CreateRegion indicates an expected call of CreateRegion.
+func (mr *MockOperatorMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplates", reflect.TypeOf((*MockOperator)(nil).ListTemplates), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockOperator)(nil).CreateRegion), ctx, region)
 }
 
-// WatchTemplates mocks base method
-func (m *MockOperator) WatchTemplates(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchTemplates", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchTemplates indicates an expected call of WatchTemplates
-func (mr *MockOperatorMockRecorder) WatchTemplates(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTemplates", reflect.TypeOf((*MockOperator)(nil).WatchTemplates), ctx, query)
-}
-
-// GetTemplate mocks base method
-func (m *MockOperator) GetTemplate(ctx context.Context, name string) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplate", ctx, name)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTemplate indicates an expected call of GetTemplate
-func (mr *MockOperatorMockRecorder) GetTemplate(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockOperator)(nil).GetTemplate), ctx, name)
-}
-
-// ListTemplatesEx mocks base method
-func (m *MockOperator) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTemplatesEx indicates an expected call of ListTemplatesEx
-func (mr *MockOperatorMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockOperator)(nil).ListTemplatesEx), ctx, query)
-}
-
-// GetTemplateEx mocks base method
-func (m *MockOperator) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
-	ret0, _ := ret[0].(*v1.Template)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTemplateEx indicates an expected call of GetTemplateEx
-func (mr *MockOperatorMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockOperator)(nil).GetTemplateEx), ctx, name, resourceVersion)
-}
-
-// CreateTemplate mocks base method
+// CreateTemplate mocks base method.
 func (m *MockOperator) CreateTemplate(ctc context.Context, template *v1.Template) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTemplate", ctc, template)
@@ -1803,13 +1030,723 @@ func (m *MockOperator) CreateTemplate(ctc context.Context, template *v1.Template
 	return ret0, ret1
 }
 
-// CreateTemplate indicates an expected call of CreateTemplate
+// CreateTemplate indicates an expected call of CreateTemplate.
 func (mr *MockOperatorMockRecorder) CreateTemplate(ctc, template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTemplate", reflect.TypeOf((*MockOperator)(nil).CreateTemplate), ctc, template)
 }
 
-// UpdateTemplate mocks base method
+// DeleteBackup mocks base method.
+func (m *MockOperator) DeleteBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackup indicates an expected call of DeleteBackup.
+func (mr *MockOperatorMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockOperator)(nil).DeleteBackup), ctx, name)
+}
+
+// DeleteBackupPoint mocks base method.
+func (m *MockOperator) DeleteBackupPoint(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackupPoint indicates an expected call of DeleteBackupPoint.
+func (mr *MockOperatorMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockOperator)(nil).DeleteBackupPoint), ctx, name)
+}
+
+// DeleteCluster mocks base method.
+func (m *MockOperator) DeleteCluster(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCluster indicates an expected call of DeleteCluster.
+func (mr *MockOperatorMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockOperator)(nil).DeleteCluster), ctx, name)
+}
+
+// DeleteCronBackup mocks base method.
+func (m *MockOperator) DeleteCronBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackup indicates an expected call of DeleteCronBackup.
+func (mr *MockOperatorMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockOperator)(nil).DeleteCronBackup), ctx, name)
+}
+
+// DeleteCronBackupCollection mocks base method.
+func (m *MockOperator) DeleteCronBackupCollection(ctx context.Context, query *query.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackupCollection", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackupCollection indicates an expected call of DeleteCronBackupCollection.
+func (mr *MockOperatorMockRecorder) DeleteCronBackupCollection(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackupCollection", reflect.TypeOf((*MockOperator)(nil).DeleteCronBackupCollection), ctx, query)
+}
+
+// DeleteDomain mocks base method.
+func (m *MockOperator) DeleteDomain(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDomain indicates an expected call of DeleteDomain.
+func (mr *MockOperatorMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockOperator)(nil).DeleteDomain), ctx, name)
+}
+
+// DeleteNode mocks base method.
+func (m *MockOperator) DeleteNode(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNode indicates an expected call of DeleteNode.
+func (mr *MockOperatorMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockOperator)(nil).DeleteNode), ctx, name)
+}
+
+// DeleteRegion mocks base method.
+func (m *MockOperator) DeleteRegion(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRegion indicates an expected call of DeleteRegion.
+func (mr *MockOperatorMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockOperator)(nil).DeleteRegion), ctx, name)
+}
+
+// DeleteTemplate mocks base method.
+func (m *MockOperator) DeleteTemplate(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplate indicates an expected call of DeleteTemplate.
+func (mr *MockOperatorMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockOperator)(nil).DeleteTemplate), ctx, name)
+}
+
+// DeleteTemplateCollection mocks base method.
+func (m *MockOperator) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection.
+func (mr *MockOperatorMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockOperator)(nil).DeleteTemplateCollection), ctx, query)
+}
+
+// GetBackup mocks base method.
+func (m *MockOperator) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackup indicates an expected call of GetBackup.
+func (mr *MockOperatorMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockOperator)(nil).GetBackup), ctx, cluster, name)
+}
+
+// GetBackupEx mocks base method.
+func (m *MockOperator) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupEx indicates an expected call of GetBackupEx.
+func (mr *MockOperatorMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockOperator)(nil).GetBackupEx), ctx, cluster, name)
+}
+
+// GetBackupPoint mocks base method.
+func (m *MockOperator) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPoint indicates an expected call of GetBackupPoint.
+func (mr *MockOperatorMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockOperator)(nil).GetBackupPoint), ctx, name, resourceVersion)
+}
+
+// GetBackupPointEx mocks base method.
+func (m *MockOperator) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBackupPointEx indicates an expected call of GetBackupPointEx.
+func (mr *MockOperatorMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockOperator)(nil).GetBackupPointEx), ctx, name, resourceVersion)
+}
+
+// GetCluster mocks base method.
+func (m *MockOperator) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCluster indicates an expected call of GetCluster.
+func (mr *MockOperatorMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockOperator)(nil).GetCluster), ctx, name)
+}
+
+// GetClusterEx mocks base method.
+func (m *MockOperator) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterEx indicates an expected call of GetClusterEx.
+func (mr *MockOperatorMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockOperator)(nil).GetClusterEx), ctx, name, resourceVersion)
+}
+
+// GetCronBackup mocks base method.
+func (m *MockOperator) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackup indicates an expected call of GetCronBackup.
+func (mr *MockOperatorMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockOperator)(nil).GetCronBackup), ctx, name, resourceVersion)
+}
+
+// GetCronBackupEx mocks base method.
+func (m *MockOperator) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCronBackupEx indicates an expected call of GetCronBackupEx.
+func (mr *MockOperatorMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockOperator)(nil).GetCronBackupEx), ctx, name, resourceVersion)
+}
+
+// GetDomain mocks base method.
+func (m *MockOperator) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
+	ret0, _ := ret[0].(*v1.Domain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDomain indicates an expected call of GetDomain.
+func (mr *MockOperatorMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockOperator)(nil).GetDomain), ctx, name)
+}
+
+// GetNode mocks base method.
+func (m *MockOperator) GetNode(ctx context.Context, name string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNode", ctx, name)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNode indicates an expected call of GetNode.
+func (mr *MockOperatorMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockOperator)(nil).GetNode), ctx, name)
+}
+
+// GetNodeEx mocks base method.
+func (m *MockOperator) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeEx indicates an expected call of GetNodeEx.
+func (mr *MockOperatorMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockOperator)(nil).GetNodeEx), ctx, name, resourceVersion)
+}
+
+// GetRegion mocks base method.
+func (m *MockOperator) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegion indicates an expected call of GetRegion.
+func (mr *MockOperatorMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockOperator)(nil).GetRegion), ctx, name)
+}
+
+// GetRegionEx mocks base method.
+func (m *MockOperator) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Region)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRegionEx indicates an expected call of GetRegionEx.
+func (mr *MockOperatorMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockOperator)(nil).GetRegionEx), ctx, name, resourceVersion)
+}
+
+// GetTemplate mocks base method.
+func (m *MockOperator) GetTemplate(ctx context.Context, name string) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplate", ctx, name)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemplate indicates an expected call of GetTemplate.
+func (mr *MockOperatorMockRecorder) GetTemplate(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockOperator)(nil).GetTemplate), ctx, name)
+}
+
+// GetTemplateEx mocks base method.
+func (m *MockOperator) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
+	ret0, _ := ret[0].(*v1.Template)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTemplateEx indicates an expected call of GetTemplateEx.
+func (mr *MockOperatorMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockOperator)(nil).GetTemplateEx), ctx, name, resourceVersion)
+}
+
+// ListBackupEx mocks base method.
+func (m *MockOperator) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupEx indicates an expected call of ListBackupEx.
+func (mr *MockOperatorMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockOperator)(nil).ListBackupEx), ctx, query)
+}
+
+// ListBackupPointEx mocks base method.
+func (m *MockOperator) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPointEx indicates an expected call of ListBackupPointEx.
+func (mr *MockOperatorMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockOperator)(nil).ListBackupPointEx), ctx, query)
+}
+
+// ListBackupPoints mocks base method.
+func (m *MockOperator) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupPointList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPoints indicates an expected call of ListBackupPoints.
+func (mr *MockOperatorMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockOperator)(nil).ListBackupPoints), ctx, query)
+}
+
+// ListBackups mocks base method.
+func (m *MockOperator) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackups indicates an expected call of ListBackups.
+func (mr *MockOperatorMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockOperator)(nil).ListBackups), ctx, query)
+}
+
+// ListClusterEx mocks base method.
+func (m *MockOperator) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusterEx indicates an expected call of ListClusterEx.
+func (mr *MockOperatorMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockOperator)(nil).ListClusterEx), ctx, query)
+}
+
+// ListClusters mocks base method.
+func (m *MockOperator) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
+	ret0, _ := ret[0].(*v1.ClusterList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusters indicates an expected call of ListClusters.
+func (mr *MockOperatorMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockOperator)(nil).ListClusters), ctx, query)
+}
+
+// ListCronBackupEx mocks base method.
+func (m *MockOperator) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackupEx indicates an expected call of ListCronBackupEx.
+func (mr *MockOperatorMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockOperator)(nil).ListCronBackupEx), ctx, query)
+}
+
+// ListCronBackups mocks base method.
+func (m *MockOperator) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.CronBackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackups indicates an expected call of ListCronBackups.
+func (mr *MockOperatorMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockOperator)(nil).ListCronBackups), ctx, query)
+}
+
+// ListDomains mocks base method.
+func (m *MockOperator) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
+	ret0, _ := ret[0].(*v1.DomainList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomains indicates an expected call of ListDomains.
+func (mr *MockOperatorMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockOperator)(nil).ListDomains), ctx, query)
+}
+
+// ListDomainsEx mocks base method.
+func (m *MockOperator) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListDomainsEx indicates an expected call of ListDomainsEx.
+func (mr *MockOperatorMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockOperator)(nil).ListDomainsEx), ctx, query)
+}
+
+// ListNodes mocks base method.
+func (m *MockOperator) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
+	ret0, _ := ret[0].(*v1.NodeList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodes indicates an expected call of ListNodes.
+func (mr *MockOperatorMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockOperator)(nil).ListNodes), ctx, query)
+}
+
+// ListNodesEx mocks base method.
+func (m *MockOperator) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodesEx indicates an expected call of ListNodesEx.
+func (mr *MockOperatorMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockOperator)(nil).ListNodesEx), ctx, query)
+}
+
+// ListRecordsEx mocks base method.
+func (m *MockOperator) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRecordsEx indicates an expected call of ListRecordsEx.
+func (mr *MockOperatorMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockOperator)(nil).ListRecordsEx), ctx, name, subdomain, query)
+}
+
+// ListRegionEx mocks base method.
+func (m *MockOperator) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegionEx indicates an expected call of ListRegionEx.
+func (mr *MockOperatorMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockOperator)(nil).ListRegionEx), ctx, query)
+}
+
+// ListRegions mocks base method.
+func (m *MockOperator) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
+	ret0, _ := ret[0].(*v1.RegionList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegions indicates an expected call of ListRegions.
+func (mr *MockOperatorMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockOperator)(nil).ListRegions), ctx, query)
+}
+
+// ListTemplates mocks base method.
+func (m *MockOperator) ListTemplates(ctx context.Context, query *query.Query) (*v1.TemplateList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTemplates", ctx, query)
+	ret0, _ := ret[0].(*v1.TemplateList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTemplates indicates an expected call of ListTemplates.
+func (mr *MockOperatorMockRecorder) ListTemplates(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplates", reflect.TypeOf((*MockOperator)(nil).ListTemplates), ctx, query)
+}
+
+// ListTemplatesEx mocks base method.
+func (m *MockOperator) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTemplatesEx indicates an expected call of ListTemplatesEx.
+func (mr *MockOperatorMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockOperator)(nil).ListTemplatesEx), ctx, query)
+}
+
+// UpdateBackup mocks base method.
+func (m *MockOperator) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
+	ret0, _ := ret[0].(*v1.Backup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateBackup indicates an expected call of UpdateBackup.
+func (mr *MockOperatorMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockOperator)(nil).UpdateBackup), ctx, backup)
+}
+
+// UpdateBackupPoint mocks base method.
+func (m *MockOperator) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
+	ret0, _ := ret[0].(*v1.BackupPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateBackupPoint indicates an expected call of UpdateBackupPoint.
+func (mr *MockOperatorMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockOperator)(nil).UpdateBackupPoint), ctx, backupPoint)
+}
+
+// UpdateCluster mocks base method.
+func (m *MockOperator) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
+	ret0, _ := ret[0].(*v1.Cluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCluster indicates an expected call of UpdateCluster.
+func (mr *MockOperatorMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockOperator)(nil).UpdateCluster), ctx, cluster)
+}
+
+// UpdateCronBackup mocks base method.
+func (m *MockOperator) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
+	ret0, _ := ret[0].(*v1.CronBackup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateCronBackup indicates an expected call of UpdateCronBackup.
+func (mr *MockOperatorMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockOperator)(nil).UpdateCronBackup), ctx, cronBackup)
+}
+
+// UpdateDomain mocks base method.
+func (m *MockOperator) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
+	ret0, _ := ret[0].(*v1.Domain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateDomain indicates an expected call of UpdateDomain.
+func (mr *MockOperatorMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockOperator)(nil).UpdateDomain), ctx, domain)
+}
+
+// UpdateNode mocks base method.
+func (m *MockOperator) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNode indicates an expected call of UpdateNode.
+func (mr *MockOperatorMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockOperator)(nil).UpdateNode), ctx, node)
+}
+
+// UpdateTemplate mocks base method.
 func (m *MockOperator) UpdateTemplate(ctx context.Context, template *v1.Template) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTemplate", ctx, template)
@@ -1818,80 +1755,44 @@ func (m *MockOperator) UpdateTemplate(ctx context.Context, template *v1.Template
 	return ret0, ret1
 }
 
-// UpdateTemplate indicates an expected call of UpdateTemplate
+// UpdateTemplate indicates an expected call of UpdateTemplate.
 func (mr *MockOperatorMockRecorder) UpdateTemplate(ctx, template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplate", reflect.TypeOf((*MockOperator)(nil).UpdateTemplate), ctx, template)
 }
 
-// DeleteTemplate mocks base method
-func (m *MockOperator) DeleteTemplate(ctx context.Context, name string) error {
+// WatchBackupPoints mocks base method.
+func (m *MockOperator) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplate indicates an expected call of DeleteTemplate
-func (mr *MockOperatorMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockOperator)(nil).DeleteTemplate), ctx, name)
-}
-
-// DeleteTemplateCollection mocks base method
-func (m *MockOperator) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection
-func (mr *MockOperatorMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockOperator)(nil).DeleteTemplateCollection), ctx, query)
-}
-
-// MockClusterReader is a mock of ClusterReader interface
-type MockClusterReader struct {
-	ctrl     *gomock.Controller
-	recorder *MockClusterReaderMockRecorder
-}
-
-// MockClusterReaderMockRecorder is the mock recorder for MockClusterReader
-type MockClusterReaderMockRecorder struct {
-	mock *MockClusterReader
-}
-
-// NewMockClusterReader creates a new mock instance
-func NewMockClusterReader(ctrl *gomock.Controller) *MockClusterReader {
-	mock := &MockClusterReader{ctrl: ctrl}
-	mock.recorder = &MockClusterReaderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockClusterReader) EXPECT() *MockClusterReaderMockRecorder {
-	return m.recorder
-}
-
-// ListClusters mocks base method
-func (m *MockClusterReader) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
-	ret0, _ := ret[0].(*v1.ClusterList)
+	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListClusters indicates an expected call of ListClusters
-func (mr *MockClusterReaderMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
+// WatchBackupPoints indicates an expected call of WatchBackupPoints.
+func (mr *MockOperatorMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockClusterReader)(nil).ListClusters), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockOperator)(nil).WatchBackupPoints), ctx, query)
 }
 
-// WatchClusters mocks base method
-func (m *MockClusterReader) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
+// WatchBackups mocks base method.
+func (m *MockOperator) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackups indicates an expected call of WatchBackups.
+func (mr *MockOperatorMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockOperator)(nil).WatchBackups), ctx, query)
+}
+
+// WatchClusters mocks base method.
+func (m *MockOperator) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
 	ret0, _ := ret[0].(watch.Interface)
@@ -1899,13 +1800,111 @@ func (m *MockClusterReader) WatchClusters(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// WatchClusters indicates an expected call of WatchClusters
-func (mr *MockClusterReaderMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
+// WatchClusters indicates an expected call of WatchClusters.
+func (mr *MockOperatorMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockClusterReader)(nil).WatchClusters), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockOperator)(nil).WatchClusters), ctx, query)
 }
 
-// GetCluster mocks base method
+// WatchCronBackups mocks base method.
+func (m *MockOperator) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchCronBackups indicates an expected call of WatchCronBackups.
+func (mr *MockOperatorMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockOperator)(nil).WatchCronBackups), ctx, query)
+}
+
+// WatchDomain mocks base method.
+func (m *MockOperator) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchDomain indicates an expected call of WatchDomain.
+func (mr *MockOperatorMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockOperator)(nil).WatchDomain), ctx, query)
+}
+
+// WatchNodes mocks base method.
+func (m *MockOperator) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchNodes indicates an expected call of WatchNodes.
+func (mr *MockOperatorMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockOperator)(nil).WatchNodes), ctx, query)
+}
+
+// WatchRegions mocks base method.
+func (m *MockOperator) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchRegions indicates an expected call of WatchRegions.
+func (mr *MockOperatorMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockOperator)(nil).WatchRegions), ctx, query)
+}
+
+// WatchTemplates mocks base method.
+func (m *MockOperator) WatchTemplates(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchTemplates", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchTemplates indicates an expected call of WatchTemplates.
+func (mr *MockOperatorMockRecorder) WatchTemplates(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTemplates", reflect.TypeOf((*MockOperator)(nil).WatchTemplates), ctx, query)
+}
+
+// MockClusterReader is a mock of ClusterReader interface.
+type MockClusterReader struct {
+	ctrl     *gomock.Controller
+	recorder *MockClusterReaderMockRecorder
+}
+
+// MockClusterReaderMockRecorder is the mock recorder for MockClusterReader.
+type MockClusterReaderMockRecorder struct {
+	mock *MockClusterReader
+}
+
+// NewMockClusterReader creates a new mock instance.
+func NewMockClusterReader(ctrl *gomock.Controller) *MockClusterReader {
+	mock := &MockClusterReader{ctrl: ctrl}
+	mock.recorder = &MockClusterReaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockClusterReader) EXPECT() *MockClusterReaderMockRecorder {
+	return m.recorder
+}
+
+// GetCluster mocks base method.
 func (m *MockClusterReader) GetCluster(ctx context.Context, name string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCluster", ctx, name)
@@ -1914,13 +1913,13 @@ func (m *MockClusterReader) GetCluster(ctx context.Context, name string) (*v1.Cl
 	return ret0, ret1
 }
 
-// GetCluster indicates an expected call of GetCluster
+// GetCluster indicates an expected call of GetCluster.
 func (mr *MockClusterReaderMockRecorder) GetCluster(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCluster", reflect.TypeOf((*MockClusterReader)(nil).GetCluster), ctx, name)
 }
 
-// GetClusterEx mocks base method
+// GetClusterEx mocks base method.
 func (m *MockClusterReader) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
@@ -1929,13 +1928,13 @@ func (m *MockClusterReader) GetClusterEx(ctx context.Context, name, resourceVers
 	return ret0, ret1
 }
 
-// GetClusterEx indicates an expected call of GetClusterEx
+// GetClusterEx indicates an expected call of GetClusterEx.
 func (mr *MockClusterReaderMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockClusterReader)(nil).GetClusterEx), ctx, name, resourceVersion)
 }
 
-// ListClusterEx mocks base method
+// ListClusterEx mocks base method.
 func (m *MockClusterReader) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
@@ -1944,36 +1943,66 @@ func (m *MockClusterReader) ListClusterEx(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// ListClusterEx indicates an expected call of ListClusterEx
+// ListClusterEx indicates an expected call of ListClusterEx.
 func (mr *MockClusterReaderMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockClusterReader)(nil).ListClusterEx), ctx, query)
 }
 
-// MockClusterReaderEx is a mock of ClusterReaderEx interface
+// ListClusters mocks base method.
+func (m *MockClusterReader) ListClusters(ctx context.Context, query *query.Query) (*v1.ClusterList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListClusters", ctx, query)
+	ret0, _ := ret[0].(*v1.ClusterList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListClusters indicates an expected call of ListClusters.
+func (mr *MockClusterReaderMockRecorder) ListClusters(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockClusterReader)(nil).ListClusters), ctx, query)
+}
+
+// WatchClusters mocks base method.
+func (m *MockClusterReader) WatchClusters(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchClusters", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchClusters indicates an expected call of WatchClusters.
+func (mr *MockClusterReaderMockRecorder) WatchClusters(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchClusters", reflect.TypeOf((*MockClusterReader)(nil).WatchClusters), ctx, query)
+}
+
+// MockClusterReaderEx is a mock of ClusterReaderEx interface.
 type MockClusterReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterReaderExMockRecorder
 }
 
-// MockClusterReaderExMockRecorder is the mock recorder for MockClusterReaderEx
+// MockClusterReaderExMockRecorder is the mock recorder for MockClusterReaderEx.
 type MockClusterReaderExMockRecorder struct {
 	mock *MockClusterReaderEx
 }
 
-// NewMockClusterReaderEx creates a new mock instance
+// NewMockClusterReaderEx creates a new mock instance.
 func NewMockClusterReaderEx(ctrl *gomock.Controller) *MockClusterReaderEx {
 	mock := &MockClusterReaderEx{ctrl: ctrl}
 	mock.recorder = &MockClusterReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterReaderEx) EXPECT() *MockClusterReaderExMockRecorder {
 	return m.recorder
 }
 
-// GetClusterEx mocks base method
+// GetClusterEx mocks base method.
 func (m *MockClusterReaderEx) GetClusterEx(ctx context.Context, name, resourceVersion string) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetClusterEx", ctx, name, resourceVersion)
@@ -1982,13 +2011,13 @@ func (m *MockClusterReaderEx) GetClusterEx(ctx context.Context, name, resourceVe
 	return ret0, ret1
 }
 
-// GetClusterEx indicates an expected call of GetClusterEx
+// GetClusterEx indicates an expected call of GetClusterEx.
 func (mr *MockClusterReaderExMockRecorder) GetClusterEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterEx", reflect.TypeOf((*MockClusterReaderEx)(nil).GetClusterEx), ctx, name, resourceVersion)
 }
 
-// ListClusterEx mocks base method
+// ListClusterEx mocks base method.
 func (m *MockClusterReaderEx) ListClusterEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusterEx", ctx, query)
@@ -1997,36 +2026,36 @@ func (m *MockClusterReaderEx) ListClusterEx(ctx context.Context, query *query.Qu
 	return ret0, ret1
 }
 
-// ListClusterEx indicates an expected call of ListClusterEx
+// ListClusterEx indicates an expected call of ListClusterEx.
 func (mr *MockClusterReaderExMockRecorder) ListClusterEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterEx", reflect.TypeOf((*MockClusterReaderEx)(nil).ListClusterEx), ctx, query)
 }
 
-// MockClusterWriter is a mock of ClusterWriter interface
+// MockClusterWriter is a mock of ClusterWriter interface.
 type MockClusterWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockClusterWriterMockRecorder
 }
 
-// MockClusterWriterMockRecorder is the mock recorder for MockClusterWriter
+// MockClusterWriterMockRecorder is the mock recorder for MockClusterWriter.
 type MockClusterWriterMockRecorder struct {
 	mock *MockClusterWriter
 }
 
-// NewMockClusterWriter creates a new mock instance
+// NewMockClusterWriter creates a new mock instance.
 func NewMockClusterWriter(ctrl *gomock.Controller) *MockClusterWriter {
 	mock := &MockClusterWriter{ctrl: ctrl}
 	mock.recorder = &MockClusterWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClusterWriter) EXPECT() *MockClusterWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateCluster mocks base method
+// CreateCluster mocks base method.
 func (m *MockClusterWriter) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCluster", ctx, cluster)
@@ -2035,13 +2064,27 @@ func (m *MockClusterWriter) CreateCluster(ctx context.Context, cluster *v1.Clust
 	return ret0, ret1
 }
 
-// CreateCluster indicates an expected call of CreateCluster
+// CreateCluster indicates an expected call of CreateCluster.
 func (mr *MockClusterWriterMockRecorder) CreateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockClusterWriter)(nil).CreateCluster), ctx, cluster)
 }
 
-// UpdateCluster mocks base method
+// DeleteCluster mocks base method.
+func (m *MockClusterWriter) DeleteCluster(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCluster indicates an expected call of DeleteCluster.
+func (mr *MockClusterWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterWriter)(nil).DeleteCluster), ctx, name)
+}
+
+// UpdateCluster mocks base method.
 func (m *MockClusterWriter) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCluster", ctx, cluster)
@@ -2050,65 +2093,36 @@ func (m *MockClusterWriter) UpdateCluster(ctx context.Context, cluster *v1.Clust
 	return ret0, ret1
 }
 
-// UpdateCluster indicates an expected call of UpdateCluster
+// UpdateCluster indicates an expected call of UpdateCluster.
 func (mr *MockClusterWriterMockRecorder) UpdateCluster(ctx, cluster interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCluster", reflect.TypeOf((*MockClusterWriter)(nil).UpdateCluster), ctx, cluster)
 }
 
-// DeleteCluster mocks base method
-func (m *MockClusterWriter) DeleteCluster(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCluster", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCluster indicates an expected call of DeleteCluster
-func (mr *MockClusterWriterMockRecorder) DeleteCluster(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockClusterWriter)(nil).DeleteCluster), ctx, name)
-}
-
-// MockRegionReader is a mock of RegionReader interface
+// MockRegionReader is a mock of RegionReader interface.
 type MockRegionReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockRegionReaderMockRecorder
 }
 
-// MockRegionReaderMockRecorder is the mock recorder for MockRegionReader
+// MockRegionReaderMockRecorder is the mock recorder for MockRegionReader.
 type MockRegionReaderMockRecorder struct {
 	mock *MockRegionReader
 }
 
-// NewMockRegionReader creates a new mock instance
+// NewMockRegionReader creates a new mock instance.
 func NewMockRegionReader(ctrl *gomock.Controller) *MockRegionReader {
 	mock := &MockRegionReader{ctrl: ctrl}
 	mock.recorder = &MockRegionReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRegionReader) EXPECT() *MockRegionReaderMockRecorder {
 	return m.recorder
 }
 
-// ListRegions mocks base method
-func (m *MockRegionReader) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
-	ret0, _ := ret[0].(*v1.RegionList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegions indicates an expected call of ListRegions
-func (mr *MockRegionReaderMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockRegionReader)(nil).ListRegions), ctx, query)
-}
-
-// GetRegion mocks base method
+// GetRegion mocks base method.
 func (m *MockRegionReader) GetRegion(ctx context.Context, name string) (*v1.Region, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegion", ctx, name)
@@ -2117,43 +2131,13 @@ func (m *MockRegionReader) GetRegion(ctx context.Context, name string) (*v1.Regi
 	return ret0, ret1
 }
 
-// GetRegion indicates an expected call of GetRegion
+// GetRegion indicates an expected call of GetRegion.
 func (mr *MockRegionReaderMockRecorder) GetRegion(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegion", reflect.TypeOf((*MockRegionReader)(nil).GetRegion), ctx, name)
 }
 
-// WatchRegions mocks base method
-func (m *MockRegionReader) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchRegions indicates an expected call of WatchRegions
-func (mr *MockRegionReaderMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockRegionReader)(nil).WatchRegions), ctx, query)
-}
-
-// ListRegionEx mocks base method
-func (m *MockRegionReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRegionEx indicates an expected call of ListRegionEx
-func (mr *MockRegionReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockRegionReader)(nil).ListRegionEx), ctx, query)
-}
-
-// GetRegionEx mocks base method
+// GetRegionEx mocks base method.
 func (m *MockRegionReader) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
@@ -2162,37 +2146,14 @@ func (m *MockRegionReader) GetRegionEx(ctx context.Context, name, resourceVersio
 	return ret0, ret1
 }
 
-// GetRegionEx indicates an expected call of GetRegionEx
+// GetRegionEx indicates an expected call of GetRegionEx.
 func (mr *MockRegionReaderMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockRegionReader)(nil).GetRegionEx), ctx, name, resourceVersion)
 }
 
-// MockRegionReaderEx is a mock of RegionReaderEx interface
-type MockRegionReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockRegionReaderExMockRecorder
-}
-
-// MockRegionReaderExMockRecorder is the mock recorder for MockRegionReaderEx
-type MockRegionReaderExMockRecorder struct {
-	mock *MockRegionReaderEx
-}
-
-// NewMockRegionReaderEx creates a new mock instance
-func NewMockRegionReaderEx(ctrl *gomock.Controller) *MockRegionReaderEx {
-	mock := &MockRegionReaderEx{ctrl: ctrl}
-	mock.recorder = &MockRegionReaderExMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockRegionReaderEx) EXPECT() *MockRegionReaderExMockRecorder {
-	return m.recorder
-}
-
-// ListRegionEx mocks base method
-func (m *MockRegionReaderEx) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+// ListRegionEx mocks base method.
+func (m *MockRegionReader) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
 	ret0, _ := ret[0].(*models.PageableResponse)
@@ -2200,13 +2161,66 @@ func (m *MockRegionReaderEx) ListRegionEx(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// ListRegionEx indicates an expected call of ListRegionEx
-func (mr *MockRegionReaderExMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
+// ListRegionEx indicates an expected call of ListRegionEx.
+func (mr *MockRegionReaderMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockRegionReaderEx)(nil).ListRegionEx), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockRegionReader)(nil).ListRegionEx), ctx, query)
 }
 
-// GetRegionEx mocks base method
+// ListRegions mocks base method.
+func (m *MockRegionReader) ListRegions(ctx context.Context, query *query.Query) (*v1.RegionList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegions", ctx, query)
+	ret0, _ := ret[0].(*v1.RegionList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegions indicates an expected call of ListRegions.
+func (mr *MockRegionReaderMockRecorder) ListRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegions", reflect.TypeOf((*MockRegionReader)(nil).ListRegions), ctx, query)
+}
+
+// WatchRegions mocks base method.
+func (m *MockRegionReader) WatchRegions(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchRegions", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchRegions indicates an expected call of WatchRegions.
+func (mr *MockRegionReaderMockRecorder) WatchRegions(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRegions", reflect.TypeOf((*MockRegionReader)(nil).WatchRegions), ctx, query)
+}
+
+// MockRegionReaderEx is a mock of RegionReaderEx interface.
+type MockRegionReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockRegionReaderExMockRecorder
+}
+
+// MockRegionReaderExMockRecorder is the mock recorder for MockRegionReaderEx.
+type MockRegionReaderExMockRecorder struct {
+	mock *MockRegionReaderEx
+}
+
+// NewMockRegionReaderEx creates a new mock instance.
+func NewMockRegionReaderEx(ctrl *gomock.Controller) *MockRegionReaderEx {
+	mock := &MockRegionReaderEx{ctrl: ctrl}
+	mock.recorder = &MockRegionReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRegionReaderEx) EXPECT() *MockRegionReaderExMockRecorder {
+	return m.recorder
+}
+
+// GetRegionEx mocks base method.
 func (m *MockRegionReaderEx) GetRegionEx(ctx context.Context, name, resourceVersion string) (*v1.Region, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRegionEx", ctx, name, resourceVersion)
@@ -2215,36 +2229,51 @@ func (m *MockRegionReaderEx) GetRegionEx(ctx context.Context, name, resourceVers
 	return ret0, ret1
 }
 
-// GetRegionEx indicates an expected call of GetRegionEx
+// GetRegionEx indicates an expected call of GetRegionEx.
 func (mr *MockRegionReaderExMockRecorder) GetRegionEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegionEx", reflect.TypeOf((*MockRegionReaderEx)(nil).GetRegionEx), ctx, name, resourceVersion)
 }
 
-// MockRegionWriter is a mock of RegionWriter interface
+// ListRegionEx mocks base method.
+func (m *MockRegionReaderEx) ListRegionEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRegionEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRegionEx indicates an expected call of ListRegionEx.
+func (mr *MockRegionReaderExMockRecorder) ListRegionEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegionEx", reflect.TypeOf((*MockRegionReaderEx)(nil).ListRegionEx), ctx, query)
+}
+
+// MockRegionWriter is a mock of RegionWriter interface.
 type MockRegionWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockRegionWriterMockRecorder
 }
 
-// MockRegionWriterMockRecorder is the mock recorder for MockRegionWriter
+// MockRegionWriterMockRecorder is the mock recorder for MockRegionWriter.
 type MockRegionWriterMockRecorder struct {
 	mock *MockRegionWriter
 }
 
-// NewMockRegionWriter creates a new mock instance
+// NewMockRegionWriter creates a new mock instance.
 func NewMockRegionWriter(ctrl *gomock.Controller) *MockRegionWriter {
 	mock := &MockRegionWriter{ctrl: ctrl}
 	mock.recorder = &MockRegionWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRegionWriter) EXPECT() *MockRegionWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateRegion mocks base method
+// CreateRegion mocks base method.
 func (m *MockRegionWriter) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRegion", ctx, region)
@@ -2253,13 +2282,13 @@ func (m *MockRegionWriter) CreateRegion(ctx context.Context, region *v1.Region) 
 	return ret0, ret1
 }
 
-// CreateRegion indicates an expected call of CreateRegion
+// CreateRegion indicates an expected call of CreateRegion.
 func (mr *MockRegionWriterMockRecorder) CreateRegion(ctx, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegion", reflect.TypeOf((*MockRegionWriter)(nil).CreateRegion), ctx, region)
 }
 
-// DeleteRegion mocks base method
+// DeleteRegion mocks base method.
 func (m *MockRegionWriter) DeleteRegion(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRegion", ctx, name)
@@ -2267,66 +2296,36 @@ func (m *MockRegionWriter) DeleteRegion(ctx context.Context, name string) error 
 	return ret0
 }
 
-// DeleteRegion indicates an expected call of DeleteRegion
+// DeleteRegion indicates an expected call of DeleteRegion.
 func (mr *MockRegionWriterMockRecorder) DeleteRegion(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegion", reflect.TypeOf((*MockRegionWriter)(nil).DeleteRegion), ctx, name)
 }
 
-// MockNodeReader is a mock of NodeReader interface
+// MockNodeReader is a mock of NodeReader interface.
 type MockNodeReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeReaderMockRecorder
 }
 
-// MockNodeReaderMockRecorder is the mock recorder for MockNodeReader
+// MockNodeReaderMockRecorder is the mock recorder for MockNodeReader.
 type MockNodeReaderMockRecorder struct {
 	mock *MockNodeReader
 }
 
-// NewMockNodeReader creates a new mock instance
+// NewMockNodeReader creates a new mock instance.
 func NewMockNodeReader(ctrl *gomock.Controller) *MockNodeReader {
 	mock := &MockNodeReader{ctrl: ctrl}
 	mock.recorder = &MockNodeReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNodeReader) EXPECT() *MockNodeReaderMockRecorder {
 	return m.recorder
 }
 
-// ListNodes mocks base method
-func (m *MockNodeReader) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
-	ret0, _ := ret[0].(*v1.NodeList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodes indicates an expected call of ListNodes
-func (mr *MockNodeReaderMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockNodeReader)(nil).ListNodes), ctx, query)
-}
-
-// WatchNodes mocks base method
-func (m *MockNodeReader) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchNodes indicates an expected call of WatchNodes
-func (mr *MockNodeReaderMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockNodeReader)(nil).WatchNodes), ctx, query)
-}
-
-// GetNode mocks base method
+// GetNode mocks base method.
 func (m *MockNodeReader) GetNode(ctx context.Context, name string) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNode", ctx, name)
@@ -2335,13 +2334,13 @@ func (m *MockNodeReader) GetNode(ctx context.Context, name string) (*v1.Node, er
 	return ret0, ret1
 }
 
-// GetNode indicates an expected call of GetNode
+// GetNode indicates an expected call of GetNode.
 func (mr *MockNodeReaderMockRecorder) GetNode(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNode", reflect.TypeOf((*MockNodeReader)(nil).GetNode), ctx, name)
 }
 
-// GetNodeEx mocks base method
+// GetNodeEx mocks base method.
 func (m *MockNodeReader) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
@@ -2350,13 +2349,28 @@ func (m *MockNodeReader) GetNodeEx(ctx context.Context, name, resourceVersion st
 	return ret0, ret1
 }
 
-// GetNodeEx indicates an expected call of GetNodeEx
+// GetNodeEx indicates an expected call of GetNodeEx.
 func (mr *MockNodeReaderMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockNodeReader)(nil).GetNodeEx), ctx, name, resourceVersion)
 }
 
-// ListNodesEx mocks base method
+// ListNodes mocks base method.
+func (m *MockNodeReader) ListNodes(ctx context.Context, query *query.Query) (*v1.NodeList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNodes", ctx, query)
+	ret0, _ := ret[0].(*v1.NodeList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNodes indicates an expected call of ListNodes.
+func (mr *MockNodeReaderMockRecorder) ListNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodes", reflect.TypeOf((*MockNodeReader)(nil).ListNodes), ctx, query)
+}
+
+// ListNodesEx mocks base method.
 func (m *MockNodeReader) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
@@ -2365,36 +2379,51 @@ func (m *MockNodeReader) ListNodesEx(ctx context.Context, query *query.Query) (*
 	return ret0, ret1
 }
 
-// ListNodesEx indicates an expected call of ListNodesEx
+// ListNodesEx indicates an expected call of ListNodesEx.
 func (mr *MockNodeReaderMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockNodeReader)(nil).ListNodesEx), ctx, query)
 }
 
-// MockNodeReaderEx is a mock of NodeReaderEx interface
+// WatchNodes mocks base method.
+func (m *MockNodeReader) WatchNodes(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchNodes", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchNodes indicates an expected call of WatchNodes.
+func (mr *MockNodeReaderMockRecorder) WatchNodes(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNodes", reflect.TypeOf((*MockNodeReader)(nil).WatchNodes), ctx, query)
+}
+
+// MockNodeReaderEx is a mock of NodeReaderEx interface.
 type MockNodeReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeReaderExMockRecorder
 }
 
-// MockNodeReaderExMockRecorder is the mock recorder for MockNodeReaderEx
+// MockNodeReaderExMockRecorder is the mock recorder for MockNodeReaderEx.
 type MockNodeReaderExMockRecorder struct {
 	mock *MockNodeReaderEx
 }
 
-// NewMockNodeReaderEx creates a new mock instance
+// NewMockNodeReaderEx creates a new mock instance.
 func NewMockNodeReaderEx(ctrl *gomock.Controller) *MockNodeReaderEx {
 	mock := &MockNodeReaderEx{ctrl: ctrl}
 	mock.recorder = &MockNodeReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNodeReaderEx) EXPECT() *MockNodeReaderExMockRecorder {
 	return m.recorder
 }
 
-// GetNodeEx mocks base method
+// GetNodeEx mocks base method.
 func (m *MockNodeReaderEx) GetNodeEx(ctx context.Context, name, resourceVersion string) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNodeEx", ctx, name, resourceVersion)
@@ -2403,13 +2432,13 @@ func (m *MockNodeReaderEx) GetNodeEx(ctx context.Context, name, resourceVersion 
 	return ret0, ret1
 }
 
-// GetNodeEx indicates an expected call of GetNodeEx
+// GetNodeEx indicates an expected call of GetNodeEx.
 func (mr *MockNodeReaderExMockRecorder) GetNodeEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeEx", reflect.TypeOf((*MockNodeReaderEx)(nil).GetNodeEx), ctx, name, resourceVersion)
 }
 
-// ListNodesEx mocks base method
+// ListNodesEx mocks base method.
 func (m *MockNodeReaderEx) ListNodesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListNodesEx", ctx, query)
@@ -2418,51 +2447,36 @@ func (m *MockNodeReaderEx) ListNodesEx(ctx context.Context, query *query.Query) 
 	return ret0, ret1
 }
 
-// ListNodesEx indicates an expected call of ListNodesEx
+// ListNodesEx indicates an expected call of ListNodesEx.
 func (mr *MockNodeReaderExMockRecorder) ListNodesEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodesEx", reflect.TypeOf((*MockNodeReaderEx)(nil).ListNodesEx), ctx, query)
 }
 
-// MockNodeWriter is a mock of NodeWriter interface
+// MockNodeWriter is a mock of NodeWriter interface.
 type MockNodeWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockNodeWriterMockRecorder
 }
 
-// MockNodeWriterMockRecorder is the mock recorder for MockNodeWriter
+// MockNodeWriterMockRecorder is the mock recorder for MockNodeWriter.
 type MockNodeWriterMockRecorder struct {
 	mock *MockNodeWriter
 }
 
-// NewMockNodeWriter creates a new mock instance
+// NewMockNodeWriter creates a new mock instance.
 func NewMockNodeWriter(ctrl *gomock.Controller) *MockNodeWriter {
 	mock := &MockNodeWriter{ctrl: ctrl}
 	mock.recorder = &MockNodeWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockNodeWriter) EXPECT() *MockNodeWriterMockRecorder {
 	return m.recorder
 }
 
-// UpdateNode mocks base method
-func (m *MockNodeWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
-	ret0, _ := ret[0].(*v1.Node)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateNode indicates an expected call of UpdateNode
-func (mr *MockNodeWriterMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockNodeWriter)(nil).UpdateNode), ctx, node)
-}
-
-// CreateNode mocks base method
+// CreateNode mocks base method.
 func (m *MockNodeWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNode", ctx, node)
@@ -2471,13 +2485,13 @@ func (m *MockNodeWriter) CreateNode(ctx context.Context, node *v1.Node) (*v1.Nod
 	return ret0, ret1
 }
 
-// CreateNode indicates an expected call of CreateNode
+// CreateNode indicates an expected call of CreateNode.
 func (mr *MockNodeWriterMockRecorder) CreateNode(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNode", reflect.TypeOf((*MockNodeWriter)(nil).CreateNode), ctx, node)
 }
 
-// DeleteNode mocks base method
+// DeleteNode mocks base method.
 func (m *MockNodeWriter) DeleteNode(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNode", ctx, name)
@@ -2485,66 +2499,51 @@ func (m *MockNodeWriter) DeleteNode(ctx context.Context, name string) error {
 	return ret0
 }
 
-// DeleteNode indicates an expected call of DeleteNode
+// DeleteNode indicates an expected call of DeleteNode.
 func (mr *MockNodeWriterMockRecorder) DeleteNode(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNode", reflect.TypeOf((*MockNodeWriter)(nil).DeleteNode), ctx, name)
 }
 
-// MockBackupReader is a mock of BackupReader interface
+// UpdateNode mocks base method.
+func (m *MockNodeWriter) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNode", ctx, node)
+	ret0, _ := ret[0].(*v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNode indicates an expected call of UpdateNode.
+func (mr *MockNodeWriterMockRecorder) UpdateNode(ctx, node interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNode", reflect.TypeOf((*MockNodeWriter)(nil).UpdateNode), ctx, node)
+}
+
+// MockBackupReader is a mock of BackupReader interface.
 type MockBackupReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupReaderMockRecorder
 }
 
-// MockBackupReaderMockRecorder is the mock recorder for MockBackupReader
+// MockBackupReaderMockRecorder is the mock recorder for MockBackupReader.
 type MockBackupReaderMockRecorder struct {
 	mock *MockBackupReader
 }
 
-// NewMockBackupReader creates a new mock instance
+// NewMockBackupReader creates a new mock instance.
 func NewMockBackupReader(ctrl *gomock.Controller) *MockBackupReader {
 	mock := &MockBackupReader{ctrl: ctrl}
 	mock.recorder = &MockBackupReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackupReader) EXPECT() *MockBackupReaderMockRecorder {
 	return m.recorder
 }
 
-// ListBackups mocks base method
-func (m *MockBackupReader) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackups indicates an expected call of ListBackups
-func (mr *MockBackupReaderMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockBackupReader)(nil).ListBackups), ctx, query)
-}
-
-// WatchBackups mocks base method
-func (m *MockBackupReader) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackups indicates an expected call of WatchBackups
-func (mr *MockBackupReaderMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockBackupReader)(nil).WatchBackups), ctx, query)
-}
-
-// GetBackup mocks base method
+// GetBackup mocks base method.
 func (m *MockBackupReader) GetBackup(ctx context.Context, cluster, name string) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackup", ctx, cluster, name)
@@ -2553,28 +2552,13 @@ func (m *MockBackupReader) GetBackup(ctx context.Context, cluster, name string) 
 	return ret0, ret1
 }
 
-// GetBackup indicates an expected call of GetBackup
+// GetBackup indicates an expected call of GetBackup.
 func (mr *MockBackupReaderMockRecorder) GetBackup(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackup", reflect.TypeOf((*MockBackupReader)(nil).GetBackup), ctx, cluster, name)
 }
 
-// ListBackupEx mocks base method
-func (m *MockBackupReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupEx indicates an expected call of ListBackupEx
-func (mr *MockBackupReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockBackupReader)(nil).ListBackupEx), ctx, query)
-}
-
-// GetBackupEx mocks base method
+// GetBackupEx mocks base method.
 func (m *MockBackupReader) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
@@ -2583,37 +2567,14 @@ func (m *MockBackupReader) GetBackupEx(ctx context.Context, cluster, name string
 	return ret0, ret1
 }
 
-// GetBackupEx indicates an expected call of GetBackupEx
+// GetBackupEx indicates an expected call of GetBackupEx.
 func (mr *MockBackupReaderMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockBackupReader)(nil).GetBackupEx), ctx, cluster, name)
 }
 
-// MockBackupReaderEx is a mock of BackupReaderEx interface
-type MockBackupReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockBackupReaderExMockRecorder
-}
-
-// MockBackupReaderExMockRecorder is the mock recorder for MockBackupReaderEx
-type MockBackupReaderExMockRecorder struct {
-	mock *MockBackupReaderEx
-}
-
-// NewMockBackupReaderEx creates a new mock instance
-func NewMockBackupReaderEx(ctrl *gomock.Controller) *MockBackupReaderEx {
-	mock := &MockBackupReaderEx{ctrl: ctrl}
-	mock.recorder = &MockBackupReaderExMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockBackupReaderEx) EXPECT() *MockBackupReaderExMockRecorder {
-	return m.recorder
-}
-
-// ListBackupEx mocks base method
-func (m *MockBackupReaderEx) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+// ListBackupEx mocks base method.
+func (m *MockBackupReader) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
 	ret0, _ := ret[0].(*models.PageableResponse)
@@ -2621,13 +2582,66 @@ func (m *MockBackupReaderEx) ListBackupEx(ctx context.Context, query *query.Quer
 	return ret0, ret1
 }
 
-// ListBackupEx indicates an expected call of ListBackupEx
-func (mr *MockBackupReaderExMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
+// ListBackupEx indicates an expected call of ListBackupEx.
+func (mr *MockBackupReaderMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockBackupReaderEx)(nil).ListBackupEx), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockBackupReader)(nil).ListBackupEx), ctx, query)
 }
 
-// GetBackupEx mocks base method
+// ListBackups mocks base method.
+func (m *MockBackupReader) ListBackups(ctx context.Context, query *query.Query) (*v1.BackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackups indicates an expected call of ListBackups.
+func (mr *MockBackupReaderMockRecorder) ListBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackups", reflect.TypeOf((*MockBackupReader)(nil).ListBackups), ctx, query)
+}
+
+// WatchBackups mocks base method.
+func (m *MockBackupReader) WatchBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackups indicates an expected call of WatchBackups.
+func (mr *MockBackupReaderMockRecorder) WatchBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackups", reflect.TypeOf((*MockBackupReader)(nil).WatchBackups), ctx, query)
+}
+
+// MockBackupReaderEx is a mock of BackupReaderEx interface.
+type MockBackupReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockBackupReaderExMockRecorder
+}
+
+// MockBackupReaderExMockRecorder is the mock recorder for MockBackupReaderEx.
+type MockBackupReaderExMockRecorder struct {
+	mock *MockBackupReaderEx
+}
+
+// NewMockBackupReaderEx creates a new mock instance.
+func NewMockBackupReaderEx(ctrl *gomock.Controller) *MockBackupReaderEx {
+	mock := &MockBackupReaderEx{ctrl: ctrl}
+	mock.recorder = &MockBackupReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockBackupReaderEx) EXPECT() *MockBackupReaderExMockRecorder {
+	return m.recorder
+}
+
+// GetBackupEx mocks base method.
 func (m *MockBackupReaderEx) GetBackupEx(ctx context.Context, cluster, name string) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupEx", ctx, cluster, name)
@@ -2636,36 +2650,51 @@ func (m *MockBackupReaderEx) GetBackupEx(ctx context.Context, cluster, name stri
 	return ret0, ret1
 }
 
-// GetBackupEx indicates an expected call of GetBackupEx
+// GetBackupEx indicates an expected call of GetBackupEx.
 func (mr *MockBackupReaderExMockRecorder) GetBackupEx(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupEx", reflect.TypeOf((*MockBackupReaderEx)(nil).GetBackupEx), ctx, cluster, name)
 }
 
-// MockBackupWriter is a mock of BackupWriter interface
+// ListBackupEx mocks base method.
+func (m *MockBackupReaderEx) ListBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupEx indicates an expected call of ListBackupEx.
+func (mr *MockBackupReaderExMockRecorder) ListBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupEx", reflect.TypeOf((*MockBackupReaderEx)(nil).ListBackupEx), ctx, query)
+}
+
+// MockBackupWriter is a mock of BackupWriter interface.
 type MockBackupWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupWriterMockRecorder
 }
 
-// MockBackupWriterMockRecorder is the mock recorder for MockBackupWriter
+// MockBackupWriterMockRecorder is the mock recorder for MockBackupWriter.
 type MockBackupWriterMockRecorder struct {
 	mock *MockBackupWriter
 }
 
-// NewMockBackupWriter creates a new mock instance
+// NewMockBackupWriter creates a new mock instance.
 func NewMockBackupWriter(ctrl *gomock.Controller) *MockBackupWriter {
 	mock := &MockBackupWriter{ctrl: ctrl}
 	mock.recorder = &MockBackupWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackupWriter) EXPECT() *MockBackupWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateBackup mocks base method
+// CreateBackup mocks base method.
 func (m *MockBackupWriter) CreateBackup(ctc context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackup", ctc, backup)
@@ -2674,13 +2703,27 @@ func (m *MockBackupWriter) CreateBackup(ctc context.Context, backup *v1.Backup) 
 	return ret0, ret1
 }
 
-// CreateBackup indicates an expected call of CreateBackup
+// CreateBackup indicates an expected call of CreateBackup.
 func (mr *MockBackupWriterMockRecorder) CreateBackup(ctc, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackup", reflect.TypeOf((*MockBackupWriter)(nil).CreateBackup), ctc, backup)
 }
 
-// UpdateBackup mocks base method
+// DeleteBackup mocks base method.
+func (m *MockBackupWriter) DeleteBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackup indicates an expected call of DeleteBackup.
+func (mr *MockBackupWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockBackupWriter)(nil).DeleteBackup), ctx, name)
+}
+
+// UpdateBackup mocks base method.
 func (m *MockBackupWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBackup", ctx, backup)
@@ -2689,80 +2732,36 @@ func (m *MockBackupWriter) UpdateBackup(ctx context.Context, backup *v1.Backup) 
 	return ret0, ret1
 }
 
-// UpdateBackup indicates an expected call of UpdateBackup
+// UpdateBackup indicates an expected call of UpdateBackup.
 func (mr *MockBackupWriterMockRecorder) UpdateBackup(ctx, backup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackup", reflect.TypeOf((*MockBackupWriter)(nil).UpdateBackup), ctx, backup)
 }
 
-// DeleteBackup mocks base method
-func (m *MockBackupWriter) DeleteBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackup indicates an expected call of DeleteBackup
-func (mr *MockBackupWriterMockRecorder) DeleteBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackup", reflect.TypeOf((*MockBackupWriter)(nil).DeleteBackup), ctx, name)
-}
-
-// MockRecoveryReader is a mock of RecoveryReader interface
+// MockRecoveryReader is a mock of RecoveryReader interface.
 type MockRecoveryReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockRecoveryReaderMockRecorder
 }
 
-// MockRecoveryReaderMockRecorder is the mock recorder for MockRecoveryReader
+// MockRecoveryReaderMockRecorder is the mock recorder for MockRecoveryReader.
 type MockRecoveryReaderMockRecorder struct {
 	mock *MockRecoveryReader
 }
 
-// NewMockRecoveryReader creates a new mock instance
+// NewMockRecoveryReader creates a new mock instance.
 func NewMockRecoveryReader(ctrl *gomock.Controller) *MockRecoveryReader {
 	mock := &MockRecoveryReader{ctrl: ctrl}
 	mock.recorder = &MockRecoveryReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRecoveryReader) EXPECT() *MockRecoveryReaderMockRecorder {
 	return m.recorder
 }
 
-// ListRecoveries mocks base method
-func (m *MockRecoveryReader) ListRecoveries(ctx context.Context, query *query.Query) (*v1.RecoveryList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecoveries", ctx, query)
-	ret0, _ := ret[0].(*v1.RecoveryList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecoveries indicates an expected call of ListRecoveries
-func (mr *MockRecoveryReaderMockRecorder) ListRecoveries(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveries", reflect.TypeOf((*MockRecoveryReader)(nil).ListRecoveries), ctx, query)
-}
-
-// WatchRecoveries mocks base method
-func (m *MockRecoveryReader) WatchRecoveries(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchRecoveries", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchRecoveries indicates an expected call of WatchRecoveries
-func (mr *MockRecoveryReaderMockRecorder) WatchRecoveries(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRecoveries", reflect.TypeOf((*MockRecoveryReader)(nil).WatchRecoveries), ctx, query)
-}
-
-// GetRecovery mocks base method
+// GetRecovery mocks base method.
 func (m *MockRecoveryReader) GetRecovery(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecovery", ctx, cluster, name)
@@ -2771,28 +2770,13 @@ func (m *MockRecoveryReader) GetRecovery(ctx context.Context, cluster, name stri
 	return ret0, ret1
 }
 
-// GetRecovery indicates an expected call of GetRecovery
+// GetRecovery indicates an expected call of GetRecovery.
 func (mr *MockRecoveryReaderMockRecorder) GetRecovery(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecovery", reflect.TypeOf((*MockRecoveryReader)(nil).GetRecovery), ctx, cluster, name)
 }
 
-// ListRecoveryEx mocks base method
-func (m *MockRecoveryReader) ListRecoveryEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecoveryEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecoveryEx indicates an expected call of ListRecoveryEx
-func (mr *MockRecoveryReaderMockRecorder) ListRecoveryEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveryEx", reflect.TypeOf((*MockRecoveryReader)(nil).ListRecoveryEx), ctx, query)
-}
-
-// GetRecoveryEx mocks base method
+// GetRecoveryEx mocks base method.
 func (m *MockRecoveryReader) GetRecoveryEx(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecoveryEx", ctx, cluster, name)
@@ -2801,37 +2785,29 @@ func (m *MockRecoveryReader) GetRecoveryEx(ctx context.Context, cluster, name st
 	return ret0, ret1
 }
 
-// GetRecoveryEx indicates an expected call of GetRecoveryEx
+// GetRecoveryEx indicates an expected call of GetRecoveryEx.
 func (mr *MockRecoveryReaderMockRecorder) GetRecoveryEx(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecoveryEx", reflect.TypeOf((*MockRecoveryReader)(nil).GetRecoveryEx), ctx, cluster, name)
 }
 
-// MockRecoveryReaderEx is a mock of RecoveryReaderEx interface
-type MockRecoveryReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockRecoveryReaderExMockRecorder
+// ListRecoveries mocks base method.
+func (m *MockRecoveryReader) ListRecoveries(ctx context.Context, query *query.Query) (*v1.RecoveryList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecoveries", ctx, query)
+	ret0, _ := ret[0].(*v1.RecoveryList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// MockRecoveryReaderExMockRecorder is the mock recorder for MockRecoveryReaderEx
-type MockRecoveryReaderExMockRecorder struct {
-	mock *MockRecoveryReaderEx
+// ListRecoveries indicates an expected call of ListRecoveries.
+func (mr *MockRecoveryReaderMockRecorder) ListRecoveries(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveries", reflect.TypeOf((*MockRecoveryReader)(nil).ListRecoveries), ctx, query)
 }
 
-// NewMockRecoveryReaderEx creates a new mock instance
-func NewMockRecoveryReaderEx(ctrl *gomock.Controller) *MockRecoveryReaderEx {
-	mock := &MockRecoveryReaderEx{ctrl: ctrl}
-	mock.recorder = &MockRecoveryReaderExMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockRecoveryReaderEx) EXPECT() *MockRecoveryReaderExMockRecorder {
-	return m.recorder
-}
-
-// ListRecoveryEx mocks base method
-func (m *MockRecoveryReaderEx) ListRecoveryEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+// ListRecoveryEx mocks base method.
+func (m *MockRecoveryReader) ListRecoveryEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRecoveryEx", ctx, query)
 	ret0, _ := ret[0].(*models.PageableResponse)
@@ -2839,13 +2815,51 @@ func (m *MockRecoveryReaderEx) ListRecoveryEx(ctx context.Context, query *query.
 	return ret0, ret1
 }
 
-// ListRecoveryEx indicates an expected call of ListRecoveryEx
-func (mr *MockRecoveryReaderExMockRecorder) ListRecoveryEx(ctx, query interface{}) *gomock.Call {
+// ListRecoveryEx indicates an expected call of ListRecoveryEx.
+func (mr *MockRecoveryReaderMockRecorder) ListRecoveryEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveryEx", reflect.TypeOf((*MockRecoveryReaderEx)(nil).ListRecoveryEx), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveryEx", reflect.TypeOf((*MockRecoveryReader)(nil).ListRecoveryEx), ctx, query)
 }
 
-// GetRecoveryEx mocks base method
+// WatchRecoveries mocks base method.
+func (m *MockRecoveryReader) WatchRecoveries(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchRecoveries", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchRecoveries indicates an expected call of WatchRecoveries.
+func (mr *MockRecoveryReaderMockRecorder) WatchRecoveries(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRecoveries", reflect.TypeOf((*MockRecoveryReader)(nil).WatchRecoveries), ctx, query)
+}
+
+// MockRecoveryReaderEx is a mock of RecoveryReaderEx interface.
+type MockRecoveryReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockRecoveryReaderExMockRecorder
+}
+
+// MockRecoveryReaderExMockRecorder is the mock recorder for MockRecoveryReaderEx.
+type MockRecoveryReaderExMockRecorder struct {
+	mock *MockRecoveryReaderEx
+}
+
+// NewMockRecoveryReaderEx creates a new mock instance.
+func NewMockRecoveryReaderEx(ctrl *gomock.Controller) *MockRecoveryReaderEx {
+	mock := &MockRecoveryReaderEx{ctrl: ctrl}
+	mock.recorder = &MockRecoveryReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRecoveryReaderEx) EXPECT() *MockRecoveryReaderExMockRecorder {
+	return m.recorder
+}
+
+// GetRecoveryEx mocks base method.
 func (m *MockRecoveryReaderEx) GetRecoveryEx(ctx context.Context, cluster, name string) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecoveryEx", ctx, cluster, name)
@@ -2854,36 +2868,51 @@ func (m *MockRecoveryReaderEx) GetRecoveryEx(ctx context.Context, cluster, name 
 	return ret0, ret1
 }
 
-// GetRecoveryEx indicates an expected call of GetRecoveryEx
+// GetRecoveryEx indicates an expected call of GetRecoveryEx.
 func (mr *MockRecoveryReaderExMockRecorder) GetRecoveryEx(ctx, cluster, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecoveryEx", reflect.TypeOf((*MockRecoveryReaderEx)(nil).GetRecoveryEx), ctx, cluster, name)
 }
 
-// MockRecoveryWriter is a mock of RecoveryWriter interface
+// ListRecoveryEx mocks base method.
+func (m *MockRecoveryReaderEx) ListRecoveryEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecoveryEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRecoveryEx indicates an expected call of ListRecoveryEx.
+func (mr *MockRecoveryReaderExMockRecorder) ListRecoveryEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecoveryEx", reflect.TypeOf((*MockRecoveryReaderEx)(nil).ListRecoveryEx), ctx, query)
+}
+
+// MockRecoveryWriter is a mock of RecoveryWriter interface.
 type MockRecoveryWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockRecoveryWriterMockRecorder
 }
 
-// MockRecoveryWriterMockRecorder is the mock recorder for MockRecoveryWriter
+// MockRecoveryWriterMockRecorder is the mock recorder for MockRecoveryWriter.
 type MockRecoveryWriterMockRecorder struct {
 	mock *MockRecoveryWriter
 }
 
-// NewMockRecoveryWriter creates a new mock instance
+// NewMockRecoveryWriter creates a new mock instance.
 func NewMockRecoveryWriter(ctrl *gomock.Controller) *MockRecoveryWriter {
 	mock := &MockRecoveryWriter{ctrl: ctrl}
 	mock.recorder = &MockRecoveryWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRecoveryWriter) EXPECT() *MockRecoveryWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateRecovery mocks base method
+// CreateRecovery mocks base method.
 func (m *MockRecoveryWriter) CreateRecovery(ctc context.Context, recovery *v1.Recovery) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRecovery", ctc, recovery)
@@ -2892,13 +2921,27 @@ func (m *MockRecoveryWriter) CreateRecovery(ctc context.Context, recovery *v1.Re
 	return ret0, ret1
 }
 
-// CreateRecovery indicates an expected call of CreateRecovery
+// CreateRecovery indicates an expected call of CreateRecovery.
 func (mr *MockRecoveryWriterMockRecorder) CreateRecovery(ctc, recovery interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).CreateRecovery), ctc, recovery)
 }
 
-// UpdateRecovery mocks base method
+// DeleteRecovery mocks base method.
+func (m *MockRecoveryWriter) DeleteRecovery(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRecovery", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRecovery indicates an expected call of DeleteRecovery.
+func (mr *MockRecoveryWriterMockRecorder) DeleteRecovery(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).DeleteRecovery), ctx, name)
+}
+
+// UpdateRecovery mocks base method.
 func (m *MockRecoveryWriter) UpdateRecovery(ctx context.Context, recovery *v1.Recovery) (*v1.Recovery, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRecovery", ctx, recovery)
@@ -2907,65 +2950,36 @@ func (m *MockRecoveryWriter) UpdateRecovery(ctx context.Context, recovery *v1.Re
 	return ret0, ret1
 }
 
-// UpdateRecovery indicates an expected call of UpdateRecovery
+// UpdateRecovery indicates an expected call of UpdateRecovery.
 func (mr *MockRecoveryWriterMockRecorder) UpdateRecovery(ctx, recovery interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).UpdateRecovery), ctx, recovery)
 }
 
-// DeleteRecovery mocks base method
-func (m *MockRecoveryWriter) DeleteRecovery(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRecovery", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteRecovery indicates an expected call of DeleteRecovery
-func (mr *MockRecoveryWriterMockRecorder) DeleteRecovery(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRecovery", reflect.TypeOf((*MockRecoveryWriter)(nil).DeleteRecovery), ctx, name)
-}
-
-// MockBackupPointReaderEx is a mock of BackupPointReaderEx interface
+// MockBackupPointReaderEx is a mock of BackupPointReaderEx interface.
 type MockBackupPointReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupPointReaderExMockRecorder
 }
 
-// MockBackupPointReaderExMockRecorder is the mock recorder for MockBackupPointReaderEx
+// MockBackupPointReaderExMockRecorder is the mock recorder for MockBackupPointReaderEx.
 type MockBackupPointReaderExMockRecorder struct {
 	mock *MockBackupPointReaderEx
 }
 
-// NewMockBackupPointReaderEx creates a new mock instance
+// NewMockBackupPointReaderEx creates a new mock instance.
 func NewMockBackupPointReaderEx(ctrl *gomock.Controller) *MockBackupPointReaderEx {
 	mock := &MockBackupPointReaderEx{ctrl: ctrl}
 	mock.recorder = &MockBackupPointReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackupPointReaderEx) EXPECT() *MockBackupPointReaderExMockRecorder {
 	return m.recorder
 }
 
-// ListBackupPointEx mocks base method
-func (m *MockBackupPointReaderEx) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPointEx indicates an expected call of ListBackupPointEx
-func (mr *MockBackupPointReaderExMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockBackupPointReaderEx)(nil).ListBackupPointEx), ctx, query)
-}
-
-// GetBackupPointEx mocks base method
+// GetBackupPointEx mocks base method.
 func (m *MockBackupPointReaderEx) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
@@ -2974,51 +2988,51 @@ func (m *MockBackupPointReaderEx) GetBackupPointEx(ctx context.Context, name, re
 	return ret0, ret1
 }
 
-// GetBackupPointEx indicates an expected call of GetBackupPointEx
+// GetBackupPointEx indicates an expected call of GetBackupPointEx.
 func (mr *MockBackupPointReaderExMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockBackupPointReaderEx)(nil).GetBackupPointEx), ctx, name, resourceVersion)
 }
 
-// MockBackupPointReader is a mock of BackupPointReader interface
+// ListBackupPointEx mocks base method.
+func (m *MockBackupPointReaderEx) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPointEx indicates an expected call of ListBackupPointEx.
+func (mr *MockBackupPointReaderExMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockBackupPointReaderEx)(nil).ListBackupPointEx), ctx, query)
+}
+
+// MockBackupPointReader is a mock of BackupPointReader interface.
 type MockBackupPointReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupPointReaderMockRecorder
 }
 
-// MockBackupPointReaderMockRecorder is the mock recorder for MockBackupPointReader
+// MockBackupPointReaderMockRecorder is the mock recorder for MockBackupPointReader.
 type MockBackupPointReaderMockRecorder struct {
 	mock *MockBackupPointReader
 }
 
-// NewMockBackupPointReader creates a new mock instance
+// NewMockBackupPointReader creates a new mock instance.
 func NewMockBackupPointReader(ctrl *gomock.Controller) *MockBackupPointReader {
 	mock := &MockBackupPointReader{ctrl: ctrl}
 	mock.recorder = &MockBackupPointReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackupPointReader) EXPECT() *MockBackupPointReaderMockRecorder {
 	return m.recorder
 }
 
-// ListBackupPoints mocks base method
-func (m *MockBackupPointReader) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
-	ret0, _ := ret[0].(*v1.BackupPointList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPoints indicates an expected call of ListBackupPoints
-func (mr *MockBackupPointReaderMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockBackupPointReader)(nil).ListBackupPoints), ctx, query)
-}
-
-// GetBackupPoint mocks base method
+// GetBackupPoint mocks base method.
 func (m *MockBackupPointReader) GetBackupPoint(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupPoint", ctx, name, resourceVersion)
@@ -3027,43 +3041,13 @@ func (m *MockBackupPointReader) GetBackupPoint(ctx context.Context, name, resour
 	return ret0, ret1
 }
 
-// GetBackupPoint indicates an expected call of GetBackupPoint
+// GetBackupPoint indicates an expected call of GetBackupPoint.
 func (mr *MockBackupPointReaderMockRecorder) GetBackupPoint(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPoint", reflect.TypeOf((*MockBackupPointReader)(nil).GetBackupPoint), ctx, name, resourceVersion)
 }
 
-// WatchBackupPoints mocks base method
-func (m *MockBackupPointReader) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchBackupPoints indicates an expected call of WatchBackupPoints
-func (mr *MockBackupPointReaderMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockBackupPointReader)(nil).WatchBackupPoints), ctx, query)
-}
-
-// ListBackupPointEx mocks base method
-func (m *MockBackupPointReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListBackupPointEx indicates an expected call of ListBackupPointEx
-func (mr *MockBackupPointReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockBackupPointReader)(nil).ListBackupPointEx), ctx, query)
-}
-
-// GetBackupPointEx mocks base method
+// GetBackupPointEx mocks base method.
 func (m *MockBackupPointReader) GetBackupPointEx(ctx context.Context, name, resourceVersion string) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackupPointEx", ctx, name, resourceVersion)
@@ -3072,36 +3056,81 @@ func (m *MockBackupPointReader) GetBackupPointEx(ctx context.Context, name, reso
 	return ret0, ret1
 }
 
-// GetBackupPointEx indicates an expected call of GetBackupPointEx
+// GetBackupPointEx indicates an expected call of GetBackupPointEx.
 func (mr *MockBackupPointReaderMockRecorder) GetBackupPointEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupPointEx", reflect.TypeOf((*MockBackupPointReader)(nil).GetBackupPointEx), ctx, name, resourceVersion)
 }
 
-// MockBackupPointWriter is a mock of BackupPointWriter interface
+// ListBackupPointEx mocks base method.
+func (m *MockBackupPointReader) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPointEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPointEx indicates an expected call of ListBackupPointEx.
+func (mr *MockBackupPointReaderMockRecorder) ListBackupPointEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPointEx", reflect.TypeOf((*MockBackupPointReader)(nil).ListBackupPointEx), ctx, query)
+}
+
+// ListBackupPoints mocks base method.
+func (m *MockBackupPointReader) ListBackupPoints(ctx context.Context, query *query.Query) (*v1.BackupPointList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBackupPoints", ctx, query)
+	ret0, _ := ret[0].(*v1.BackupPointList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBackupPoints indicates an expected call of ListBackupPoints.
+func (mr *MockBackupPointReaderMockRecorder) ListBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBackupPoints", reflect.TypeOf((*MockBackupPointReader)(nil).ListBackupPoints), ctx, query)
+}
+
+// WatchBackupPoints mocks base method.
+func (m *MockBackupPointReader) WatchBackupPoints(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchBackupPoints", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchBackupPoints indicates an expected call of WatchBackupPoints.
+func (mr *MockBackupPointReaderMockRecorder) WatchBackupPoints(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchBackupPoints", reflect.TypeOf((*MockBackupPointReader)(nil).WatchBackupPoints), ctx, query)
+}
+
+// MockBackupPointWriter is a mock of BackupPointWriter interface.
 type MockBackupPointWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackupPointWriterMockRecorder
 }
 
-// MockBackupPointWriterMockRecorder is the mock recorder for MockBackupPointWriter
+// MockBackupPointWriterMockRecorder is the mock recorder for MockBackupPointWriter.
 type MockBackupPointWriterMockRecorder struct {
 	mock *MockBackupPointWriter
 }
 
-// NewMockBackupPointWriter creates a new mock instance
+// NewMockBackupPointWriter creates a new mock instance.
 func NewMockBackupPointWriter(ctrl *gomock.Controller) *MockBackupPointWriter {
 	mock := &MockBackupPointWriter{ctrl: ctrl}
 	mock.recorder = &MockBackupPointWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBackupPointWriter) EXPECT() *MockBackupPointWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateBackupPoint mocks base method
+// CreateBackupPoint mocks base method.
 func (m *MockBackupPointWriter) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBackupPoint", ctx, backupPoint)
@@ -3110,13 +3139,27 @@ func (m *MockBackupPointWriter) CreateBackupPoint(ctx context.Context, backupPoi
 	return ret0, ret1
 }
 
-// CreateBackupPoint indicates an expected call of CreateBackupPoint
+// CreateBackupPoint indicates an expected call of CreateBackupPoint.
 func (mr *MockBackupPointWriterMockRecorder) CreateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).CreateBackupPoint), ctx, backupPoint)
 }
 
-// UpdateBackupPoint mocks base method
+// DeleteBackupPoint mocks base method.
+func (m *MockBackupPointWriter) DeleteBackupPoint(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteBackupPoint indicates an expected call of DeleteBackupPoint.
+func (mr *MockBackupPointWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).DeleteBackupPoint), ctx, name)
+}
+
+// UpdateBackupPoint mocks base method.
 func (m *MockBackupPointWriter) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBackupPoint", ctx, backupPoint)
@@ -3125,65 +3168,36 @@ func (m *MockBackupPointWriter) UpdateBackupPoint(ctx context.Context, backupPoi
 	return ret0, ret1
 }
 
-// UpdateBackupPoint indicates an expected call of UpdateBackupPoint
+// UpdateBackupPoint indicates an expected call of UpdateBackupPoint.
 func (mr *MockBackupPointWriterMockRecorder) UpdateBackupPoint(ctx, backupPoint interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).UpdateBackupPoint), ctx, backupPoint)
 }
 
-// DeleteBackupPoint mocks base method
-func (m *MockBackupPointWriter) DeleteBackupPoint(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBackupPoint", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteBackupPoint indicates an expected call of DeleteBackupPoint
-func (mr *MockBackupPointWriterMockRecorder) DeleteBackupPoint(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBackupPoint", reflect.TypeOf((*MockBackupPointWriter)(nil).DeleteBackupPoint), ctx, name)
-}
-
-// MockCronBackupReaderEx is a mock of CronBackupReaderEx interface
+// MockCronBackupReaderEx is a mock of CronBackupReaderEx interface.
 type MockCronBackupReaderEx struct {
 	ctrl     *gomock.Controller
 	recorder *MockCronBackupReaderExMockRecorder
 }
 
-// MockCronBackupReaderExMockRecorder is the mock recorder for MockCronBackupReaderEx
+// MockCronBackupReaderExMockRecorder is the mock recorder for MockCronBackupReaderEx.
 type MockCronBackupReaderExMockRecorder struct {
 	mock *MockCronBackupReaderEx
 }
 
-// NewMockCronBackupReaderEx creates a new mock instance
+// NewMockCronBackupReaderEx creates a new mock instance.
 func NewMockCronBackupReaderEx(ctrl *gomock.Controller) *MockCronBackupReaderEx {
 	mock := &MockCronBackupReaderEx{ctrl: ctrl}
 	mock.recorder = &MockCronBackupReaderExMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCronBackupReaderEx) EXPECT() *MockCronBackupReaderExMockRecorder {
 	return m.recorder
 }
 
-// ListCronBackupEx mocks base method
-func (m *MockCronBackupReaderEx) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackupEx indicates an expected call of ListCronBackupEx
-func (mr *MockCronBackupReaderExMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockCronBackupReaderEx)(nil).ListCronBackupEx), ctx, query)
-}
-
-// GetCronBackupEx mocks base method
+// GetCronBackupEx mocks base method.
 func (m *MockCronBackupReaderEx) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
@@ -3192,51 +3206,51 @@ func (m *MockCronBackupReaderEx) GetCronBackupEx(ctx context.Context, name, reso
 	return ret0, ret1
 }
 
-// GetCronBackupEx indicates an expected call of GetCronBackupEx
+// GetCronBackupEx indicates an expected call of GetCronBackupEx.
 func (mr *MockCronBackupReaderExMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockCronBackupReaderEx)(nil).GetCronBackupEx), ctx, name, resourceVersion)
 }
 
-// MockCronBackupReader is a mock of CronBackupReader interface
+// ListCronBackupEx mocks base method.
+func (m *MockCronBackupReaderEx) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackupEx indicates an expected call of ListCronBackupEx.
+func (mr *MockCronBackupReaderExMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockCronBackupReaderEx)(nil).ListCronBackupEx), ctx, query)
+}
+
+// MockCronBackupReader is a mock of CronBackupReader interface.
 type MockCronBackupReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockCronBackupReaderMockRecorder
 }
 
-// MockCronBackupReaderMockRecorder is the mock recorder for MockCronBackupReader
+// MockCronBackupReaderMockRecorder is the mock recorder for MockCronBackupReader.
 type MockCronBackupReaderMockRecorder struct {
 	mock *MockCronBackupReader
 }
 
-// NewMockCronBackupReader creates a new mock instance
+// NewMockCronBackupReader creates a new mock instance.
 func NewMockCronBackupReader(ctrl *gomock.Controller) *MockCronBackupReader {
 	mock := &MockCronBackupReader{ctrl: ctrl}
 	mock.recorder = &MockCronBackupReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCronBackupReader) EXPECT() *MockCronBackupReaderMockRecorder {
 	return m.recorder
 }
 
-// ListCronBackups mocks base method
-func (m *MockCronBackupReader) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
-	ret0, _ := ret[0].(*v1.CronBackupList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackups indicates an expected call of ListCronBackups
-func (mr *MockCronBackupReaderMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockCronBackupReader)(nil).ListCronBackups), ctx, query)
-}
-
-// GetCronBackup mocks base method
+// GetCronBackup mocks base method.
 func (m *MockCronBackupReader) GetCronBackup(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCronBackup", ctx, name, resourceVersion)
@@ -3245,43 +3259,13 @@ func (m *MockCronBackupReader) GetCronBackup(ctx context.Context, name, resource
 	return ret0, ret1
 }
 
-// GetCronBackup indicates an expected call of GetCronBackup
+// GetCronBackup indicates an expected call of GetCronBackup.
 func (mr *MockCronBackupReaderMockRecorder) GetCronBackup(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackup", reflect.TypeOf((*MockCronBackupReader)(nil).GetCronBackup), ctx, name, resourceVersion)
 }
 
-// WatchCronBackups mocks base method
-func (m *MockCronBackupReader) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchCronBackups indicates an expected call of WatchCronBackups
-func (mr *MockCronBackupReaderMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockCronBackupReader)(nil).WatchCronBackups), ctx, query)
-}
-
-// ListCronBackupEx mocks base method
-func (m *MockCronBackupReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListCronBackupEx indicates an expected call of ListCronBackupEx
-func (mr *MockCronBackupReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockCronBackupReader)(nil).ListCronBackupEx), ctx, query)
-}
-
-// GetCronBackupEx mocks base method
+// GetCronBackupEx mocks base method.
 func (m *MockCronBackupReader) GetCronBackupEx(ctx context.Context, name, resourceVersion string) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCronBackupEx", ctx, name, resourceVersion)
@@ -3290,36 +3274,81 @@ func (m *MockCronBackupReader) GetCronBackupEx(ctx context.Context, name, resour
 	return ret0, ret1
 }
 
-// GetCronBackupEx indicates an expected call of GetCronBackupEx
+// GetCronBackupEx indicates an expected call of GetCronBackupEx.
 func (mr *MockCronBackupReaderMockRecorder) GetCronBackupEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCronBackupEx", reflect.TypeOf((*MockCronBackupReader)(nil).GetCronBackupEx), ctx, name, resourceVersion)
 }
 
-// MockCronBackupWriter is a mock of CronBackupWriter interface
+// ListCronBackupEx mocks base method.
+func (m *MockCronBackupReader) ListCronBackupEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackupEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackupEx indicates an expected call of ListCronBackupEx.
+func (mr *MockCronBackupReaderMockRecorder) ListCronBackupEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackupEx", reflect.TypeOf((*MockCronBackupReader)(nil).ListCronBackupEx), ctx, query)
+}
+
+// ListCronBackups mocks base method.
+func (m *MockCronBackupReader) ListCronBackups(ctx context.Context, query *query.Query) (*v1.CronBackupList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCronBackups", ctx, query)
+	ret0, _ := ret[0].(*v1.CronBackupList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCronBackups indicates an expected call of ListCronBackups.
+func (mr *MockCronBackupReaderMockRecorder) ListCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCronBackups", reflect.TypeOf((*MockCronBackupReader)(nil).ListCronBackups), ctx, query)
+}
+
+// WatchCronBackups mocks base method.
+func (m *MockCronBackupReader) WatchCronBackups(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchCronBackups", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchCronBackups indicates an expected call of WatchCronBackups.
+func (mr *MockCronBackupReaderMockRecorder) WatchCronBackups(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchCronBackups", reflect.TypeOf((*MockCronBackupReader)(nil).WatchCronBackups), ctx, query)
+}
+
+// MockCronBackupWriter is a mock of CronBackupWriter interface.
 type MockCronBackupWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockCronBackupWriterMockRecorder
 }
 
-// MockCronBackupWriterMockRecorder is the mock recorder for MockCronBackupWriter
+// MockCronBackupWriterMockRecorder is the mock recorder for MockCronBackupWriter.
 type MockCronBackupWriterMockRecorder struct {
 	mock *MockCronBackupWriter
 }
 
-// NewMockCronBackupWriter creates a new mock instance
+// NewMockCronBackupWriter creates a new mock instance.
 func NewMockCronBackupWriter(ctrl *gomock.Controller) *MockCronBackupWriter {
 	mock := &MockCronBackupWriter{ctrl: ctrl}
 	mock.recorder = &MockCronBackupWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCronBackupWriter) EXPECT() *MockCronBackupWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateCronBackup mocks base method
+// CreateCronBackup mocks base method.
 func (m *MockCronBackupWriter) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCronBackup", ctx, cronBackup)
@@ -3328,13 +3357,41 @@ func (m *MockCronBackupWriter) CreateCronBackup(ctx context.Context, cronBackup 
 	return ret0, ret1
 }
 
-// CreateCronBackup indicates an expected call of CreateCronBackup
+// CreateCronBackup indicates an expected call of CreateCronBackup.
 func (mr *MockCronBackupWriterMockRecorder) CreateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).CreateCronBackup), ctx, cronBackup)
 }
 
-// UpdateCronBackup mocks base method
+// DeleteCronBackup mocks base method.
+func (m *MockCronBackupWriter) DeleteCronBackup(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackup indicates an expected call of DeleteCronBackup.
+func (mr *MockCronBackupWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).DeleteCronBackup), ctx, name)
+}
+
+// DeleteCronBackupCollection mocks base method.
+func (m *MockCronBackupWriter) DeleteCronBackupCollection(ctx context.Context, query *query.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCronBackupCollection", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCronBackupCollection indicates an expected call of DeleteCronBackupCollection.
+func (mr *MockCronBackupWriterMockRecorder) DeleteCronBackupCollection(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackupCollection", reflect.TypeOf((*MockCronBackupWriter)(nil).DeleteCronBackupCollection), ctx, query)
+}
+
+// UpdateCronBackup mocks base method.
 func (m *MockCronBackupWriter) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCronBackup", ctx, cronBackup)
@@ -3343,65 +3400,36 @@ func (m *MockCronBackupWriter) UpdateCronBackup(ctx context.Context, cronBackup 
 	return ret0, ret1
 }
 
-// UpdateCronBackup indicates an expected call of UpdateCronBackup
+// UpdateCronBackup indicates an expected call of UpdateCronBackup.
 func (mr *MockCronBackupWriterMockRecorder) UpdateCronBackup(ctx, cronBackup interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).UpdateCronBackup), ctx, cronBackup)
 }
 
-// DeleteCronBackup mocks base method
-func (m *MockCronBackupWriter) DeleteCronBackup(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCronBackup", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteCronBackup indicates an expected call of DeleteCronBackup
-func (mr *MockCronBackupWriterMockRecorder) DeleteCronBackup(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCronBackup", reflect.TypeOf((*MockCronBackupWriter)(nil).DeleteCronBackup), ctx, name)
-}
-
-// MockDNSReader is a mock of DNSReader interface
+// MockDNSReader is a mock of DNSReader interface.
 type MockDNSReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockDNSReaderMockRecorder
 }
 
-// MockDNSReaderMockRecorder is the mock recorder for MockDNSReader
+// MockDNSReaderMockRecorder is the mock recorder for MockDNSReader.
 type MockDNSReaderMockRecorder struct {
 	mock *MockDNSReader
 }
 
-// NewMockDNSReader creates a new mock instance
+// NewMockDNSReader creates a new mock instance.
 func NewMockDNSReader(ctrl *gomock.Controller) *MockDNSReader {
 	mock := &MockDNSReader{ctrl: ctrl}
 	mock.recorder = &MockDNSReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDNSReader) EXPECT() *MockDNSReaderMockRecorder {
 	return m.recorder
 }
 
-// ListDomains mocks base method
-func (m *MockDNSReader) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
-	ret0, _ := ret[0].(*v1.DomainList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListDomains indicates an expected call of ListDomains
-func (mr *MockDNSReaderMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockDNSReader)(nil).ListDomains), ctx, query)
-}
-
-// GetDomain mocks base method
+// GetDomain mocks base method.
 func (m *MockDNSReader) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDomain", ctx, name)
@@ -3410,43 +3438,28 @@ func (m *MockDNSReader) GetDomain(ctx context.Context, name string) (*v1.Domain,
 	return ret0, ret1
 }
 
-// GetDomain indicates an expected call of GetDomain
+// GetDomain indicates an expected call of GetDomain.
 func (mr *MockDNSReaderMockRecorder) GetDomain(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomain", reflect.TypeOf((*MockDNSReader)(nil).GetDomain), ctx, name)
 }
 
-// WatchDomain mocks base method
-func (m *MockDNSReader) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+// ListDomains mocks base method.
+func (m *MockDNSReader) ListDomains(ctx context.Context, query *query.Query) (*v1.DomainList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
+	ret := m.ctrl.Call(m, "ListDomains", ctx, query)
+	ret0, _ := ret[0].(*v1.DomainList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WatchDomain indicates an expected call of WatchDomain
-func (mr *MockDNSReaderMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+// ListDomains indicates an expected call of ListDomains.
+func (mr *MockDNSReaderMockRecorder) ListDomains(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockDNSReader)(nil).WatchDomain), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomains", reflect.TypeOf((*MockDNSReader)(nil).ListDomains), ctx, query)
 }
 
-// ListRecordsEx mocks base method
-func (m *MockDNSReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRecordsEx indicates an expected call of ListRecordsEx
-func (mr *MockDNSReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockDNSReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
-}
-
-// ListDomainsEx mocks base method
+// ListDomainsEx mocks base method.
 func (m *MockDNSReader) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
@@ -3455,37 +3468,14 @@ func (m *MockDNSReader) ListDomainsEx(ctx context.Context, query *query.Query) (
 	return ret0, ret1
 }
 
-// ListDomainsEx indicates an expected call of ListDomainsEx
+// ListDomainsEx indicates an expected call of ListDomainsEx.
 func (mr *MockDNSReaderMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockDNSReader)(nil).ListDomainsEx), ctx, query)
 }
 
-// MockDNSReaderEx is a mock of DNSReaderEx interface
-type MockDNSReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockDNSReaderExMockRecorder
-}
-
-// MockDNSReaderExMockRecorder is the mock recorder for MockDNSReaderEx
-type MockDNSReaderExMockRecorder struct {
-	mock *MockDNSReaderEx
-}
-
-// NewMockDNSReaderEx creates a new mock instance
-func NewMockDNSReaderEx(ctrl *gomock.Controller) *MockDNSReaderEx {
-	mock := &MockDNSReaderEx{ctrl: ctrl}
-	mock.recorder = &MockDNSReaderExMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockDNSReaderEx) EXPECT() *MockDNSReaderExMockRecorder {
-	return m.recorder
-}
-
-// ListRecordsEx mocks base method
-func (m *MockDNSReaderEx) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+// ListRecordsEx mocks base method.
+func (m *MockDNSReader) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
 	ret0, _ := ret[0].(*models.PageableResponse)
@@ -3493,13 +3483,51 @@ func (m *MockDNSReaderEx) ListRecordsEx(ctx context.Context, name, subdomain str
 	return ret0, ret1
 }
 
-// ListRecordsEx indicates an expected call of ListRecordsEx
-func (mr *MockDNSReaderExMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+// ListRecordsEx indicates an expected call of ListRecordsEx.
+func (mr *MockDNSReaderMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockDNSReaderEx)(nil).ListRecordsEx), ctx, name, subdomain, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockDNSReader)(nil).ListRecordsEx), ctx, name, subdomain, query)
 }
 
-// ListDomainsEx mocks base method
+// WatchDomain mocks base method.
+func (m *MockDNSReader) WatchDomain(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchDomain", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchDomain indicates an expected call of WatchDomain.
+func (mr *MockDNSReaderMockRecorder) WatchDomain(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchDomain", reflect.TypeOf((*MockDNSReader)(nil).WatchDomain), ctx, query)
+}
+
+// MockDNSReaderEx is a mock of DNSReaderEx interface.
+type MockDNSReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockDNSReaderExMockRecorder
+}
+
+// MockDNSReaderExMockRecorder is the mock recorder for MockDNSReaderEx.
+type MockDNSReaderExMockRecorder struct {
+	mock *MockDNSReaderEx
+}
+
+// NewMockDNSReaderEx creates a new mock instance.
+func NewMockDNSReaderEx(ctrl *gomock.Controller) *MockDNSReaderEx {
+	mock := &MockDNSReaderEx{ctrl: ctrl}
+	mock.recorder = &MockDNSReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDNSReaderEx) EXPECT() *MockDNSReaderExMockRecorder {
+	return m.recorder
+}
+
+// ListDomainsEx mocks base method.
 func (m *MockDNSReaderEx) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDomainsEx", ctx, query)
@@ -3508,36 +3536,51 @@ func (m *MockDNSReaderEx) ListDomainsEx(ctx context.Context, query *query.Query)
 	return ret0, ret1
 }
 
-// ListDomainsEx indicates an expected call of ListDomainsEx
+// ListDomainsEx indicates an expected call of ListDomainsEx.
 func (mr *MockDNSReaderExMockRecorder) ListDomainsEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDomainsEx", reflect.TypeOf((*MockDNSReaderEx)(nil).ListDomainsEx), ctx, query)
 }
 
-// MockDNSWriter is a mock of DNSWriter interface
+// ListRecordsEx mocks base method.
+func (m *MockDNSReaderEx) ListRecordsEx(ctx context.Context, name, subdomain string, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRecordsEx", ctx, name, subdomain, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRecordsEx indicates an expected call of ListRecordsEx.
+func (mr *MockDNSReaderExMockRecorder) ListRecordsEx(ctx, name, subdomain, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRecordsEx", reflect.TypeOf((*MockDNSReaderEx)(nil).ListRecordsEx), ctx, name, subdomain, query)
+}
+
+// MockDNSWriter is a mock of DNSWriter interface.
 type MockDNSWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockDNSWriterMockRecorder
 }
 
-// MockDNSWriterMockRecorder is the mock recorder for MockDNSWriter
+// MockDNSWriterMockRecorder is the mock recorder for MockDNSWriter.
 type MockDNSWriterMockRecorder struct {
 	mock *MockDNSWriter
 }
 
-// NewMockDNSWriter creates a new mock instance
+// NewMockDNSWriter creates a new mock instance.
 func NewMockDNSWriter(ctrl *gomock.Controller) *MockDNSWriter {
 	mock := &MockDNSWriter{ctrl: ctrl}
 	mock.recorder = &MockDNSWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDNSWriter) EXPECT() *MockDNSWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateDomain mocks base method
+// CreateDomain mocks base method.
 func (m *MockDNSWriter) CreateDomain(ctc context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDomain", ctc, domain)
@@ -3546,13 +3589,27 @@ func (m *MockDNSWriter) CreateDomain(ctc context.Context, domain *v1.Domain) (*v
 	return ret0, ret1
 }
 
-// CreateDomain indicates an expected call of CreateDomain
+// CreateDomain indicates an expected call of CreateDomain.
 func (mr *MockDNSWriterMockRecorder) CreateDomain(ctc, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDomain", reflect.TypeOf((*MockDNSWriter)(nil).CreateDomain), ctc, domain)
 }
 
-// UpdateDomain mocks base method
+// DeleteDomain mocks base method.
+func (m *MockDNSWriter) DeleteDomain(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDomain indicates an expected call of DeleteDomain.
+func (mr *MockDNSWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockDNSWriter)(nil).DeleteDomain), ctx, name)
+}
+
+// UpdateDomain mocks base method.
 func (m *MockDNSWriter) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDomain", ctx, domain)
@@ -3561,80 +3618,36 @@ func (m *MockDNSWriter) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v
 	return ret0, ret1
 }
 
-// UpdateDomain indicates an expected call of UpdateDomain
+// UpdateDomain indicates an expected call of UpdateDomain.
 func (mr *MockDNSWriterMockRecorder) UpdateDomain(ctx, domain interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockDNSWriter)(nil).UpdateDomain), ctx, domain)
 }
 
-// DeleteDomain mocks base method
-func (m *MockDNSWriter) DeleteDomain(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteDomain", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteDomain indicates an expected call of DeleteDomain
-func (mr *MockDNSWriterMockRecorder) DeleteDomain(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDomain", reflect.TypeOf((*MockDNSWriter)(nil).DeleteDomain), ctx, name)
-}
-
-// MockTemplateReader is a mock of TemplateReader interface
+// MockTemplateReader is a mock of TemplateReader interface.
 type MockTemplateReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockTemplateReaderMockRecorder
 }
 
-// MockTemplateReaderMockRecorder is the mock recorder for MockTemplateReader
+// MockTemplateReaderMockRecorder is the mock recorder for MockTemplateReader.
 type MockTemplateReaderMockRecorder struct {
 	mock *MockTemplateReader
 }
 
-// NewMockTemplateReader creates a new mock instance
+// NewMockTemplateReader creates a new mock instance.
 func NewMockTemplateReader(ctrl *gomock.Controller) *MockTemplateReader {
 	mock := &MockTemplateReader{ctrl: ctrl}
 	mock.recorder = &MockTemplateReaderMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTemplateReader) EXPECT() *MockTemplateReaderMockRecorder {
 	return m.recorder
 }
 
-// ListTemplates mocks base method
-func (m *MockTemplateReader) ListTemplates(ctx context.Context, query *query.Query) (*v1.TemplateList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTemplates", ctx, query)
-	ret0, _ := ret[0].(*v1.TemplateList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTemplates indicates an expected call of ListTemplates
-func (mr *MockTemplateReaderMockRecorder) ListTemplates(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplates", reflect.TypeOf((*MockTemplateReader)(nil).ListTemplates), ctx, query)
-}
-
-// WatchTemplates mocks base method
-func (m *MockTemplateReader) WatchTemplates(ctx context.Context, query *query.Query) (watch.Interface, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchTemplates", ctx, query)
-	ret0, _ := ret[0].(watch.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchTemplates indicates an expected call of WatchTemplates
-func (mr *MockTemplateReaderMockRecorder) WatchTemplates(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTemplates", reflect.TypeOf((*MockTemplateReader)(nil).WatchTemplates), ctx, query)
-}
-
-// GetTemplate mocks base method
+// GetTemplate mocks base method.
 func (m *MockTemplateReader) GetTemplate(ctx context.Context, name string) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplate", ctx, name)
@@ -3643,28 +3656,13 @@ func (m *MockTemplateReader) GetTemplate(ctx context.Context, name string) (*v1.
 	return ret0, ret1
 }
 
-// GetTemplate indicates an expected call of GetTemplate
+// GetTemplate indicates an expected call of GetTemplate.
 func (mr *MockTemplateReaderMockRecorder) GetTemplate(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockTemplateReader)(nil).GetTemplate), ctx, name)
 }
 
-// ListTemplatesEx mocks base method
-func (m *MockTemplateReader) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
-	ret0, _ := ret[0].(*models.PageableResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListTemplatesEx indicates an expected call of ListTemplatesEx
-func (mr *MockTemplateReaderMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockTemplateReader)(nil).ListTemplatesEx), ctx, query)
-}
-
-// GetTemplateEx mocks base method
+// GetTemplateEx mocks base method.
 func (m *MockTemplateReader) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
@@ -3673,37 +3671,29 @@ func (m *MockTemplateReader) GetTemplateEx(ctx context.Context, name, resourceVe
 	return ret0, ret1
 }
 
-// GetTemplateEx indicates an expected call of GetTemplateEx
+// GetTemplateEx indicates an expected call of GetTemplateEx.
 func (mr *MockTemplateReaderMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockTemplateReader)(nil).GetTemplateEx), ctx, name, resourceVersion)
 }
 
-// MockTemplateReaderEx is a mock of TemplateReaderEx interface
-type MockTemplateReaderEx struct {
-	ctrl     *gomock.Controller
-	recorder *MockTemplateReaderExMockRecorder
+// ListTemplates mocks base method.
+func (m *MockTemplateReader) ListTemplates(ctx context.Context, query *query.Query) (*v1.TemplateList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTemplates", ctx, query)
+	ret0, _ := ret[0].(*v1.TemplateList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// MockTemplateReaderExMockRecorder is the mock recorder for MockTemplateReaderEx
-type MockTemplateReaderExMockRecorder struct {
-	mock *MockTemplateReaderEx
+// ListTemplates indicates an expected call of ListTemplates.
+func (mr *MockTemplateReaderMockRecorder) ListTemplates(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplates", reflect.TypeOf((*MockTemplateReader)(nil).ListTemplates), ctx, query)
 }
 
-// NewMockTemplateReaderEx creates a new mock instance
-func NewMockTemplateReaderEx(ctrl *gomock.Controller) *MockTemplateReaderEx {
-	mock := &MockTemplateReaderEx{ctrl: ctrl}
-	mock.recorder = &MockTemplateReaderExMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockTemplateReaderEx) EXPECT() *MockTemplateReaderExMockRecorder {
-	return m.recorder
-}
-
-// ListTemplatesEx mocks base method
-func (m *MockTemplateReaderEx) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+// ListTemplatesEx mocks base method.
+func (m *MockTemplateReader) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
 	ret0, _ := ret[0].(*models.PageableResponse)
@@ -3711,13 +3701,51 @@ func (m *MockTemplateReaderEx) ListTemplatesEx(ctx context.Context, query *query
 	return ret0, ret1
 }
 
-// ListTemplatesEx indicates an expected call of ListTemplatesEx
-func (mr *MockTemplateReaderExMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
+// ListTemplatesEx indicates an expected call of ListTemplatesEx.
+func (mr *MockTemplateReaderMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockTemplateReaderEx)(nil).ListTemplatesEx), ctx, query)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockTemplateReader)(nil).ListTemplatesEx), ctx, query)
 }
 
-// GetTemplateEx mocks base method
+// WatchTemplates mocks base method.
+func (m *MockTemplateReader) WatchTemplates(ctx context.Context, query *query.Query) (watch.Interface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchTemplates", ctx, query)
+	ret0, _ := ret[0].(watch.Interface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchTemplates indicates an expected call of WatchTemplates.
+func (mr *MockTemplateReaderMockRecorder) WatchTemplates(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTemplates", reflect.TypeOf((*MockTemplateReader)(nil).WatchTemplates), ctx, query)
+}
+
+// MockTemplateReaderEx is a mock of TemplateReaderEx interface.
+type MockTemplateReaderEx struct {
+	ctrl     *gomock.Controller
+	recorder *MockTemplateReaderExMockRecorder
+}
+
+// MockTemplateReaderExMockRecorder is the mock recorder for MockTemplateReaderEx.
+type MockTemplateReaderExMockRecorder struct {
+	mock *MockTemplateReaderEx
+}
+
+// NewMockTemplateReaderEx creates a new mock instance.
+func NewMockTemplateReaderEx(ctrl *gomock.Controller) *MockTemplateReaderEx {
+	mock := &MockTemplateReaderEx{ctrl: ctrl}
+	mock.recorder = &MockTemplateReaderExMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTemplateReaderEx) EXPECT() *MockTemplateReaderExMockRecorder {
+	return m.recorder
+}
+
+// GetTemplateEx mocks base method.
 func (m *MockTemplateReaderEx) GetTemplateEx(ctx context.Context, name, resourceVersion string) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplateEx", ctx, name, resourceVersion)
@@ -3726,36 +3754,51 @@ func (m *MockTemplateReaderEx) GetTemplateEx(ctx context.Context, name, resource
 	return ret0, ret1
 }
 
-// GetTemplateEx indicates an expected call of GetTemplateEx
+// GetTemplateEx indicates an expected call of GetTemplateEx.
 func (mr *MockTemplateReaderExMockRecorder) GetTemplateEx(ctx, name, resourceVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateEx", reflect.TypeOf((*MockTemplateReaderEx)(nil).GetTemplateEx), ctx, name, resourceVersion)
 }
 
-// MockTemplateWriter is a mock of TemplateWriter interface
+// ListTemplatesEx mocks base method.
+func (m *MockTemplateReaderEx) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTemplatesEx", ctx, query)
+	ret0, _ := ret[0].(*models.PageableResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTemplatesEx indicates an expected call of ListTemplatesEx.
+func (mr *MockTemplateReaderExMockRecorder) ListTemplatesEx(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTemplatesEx", reflect.TypeOf((*MockTemplateReaderEx)(nil).ListTemplatesEx), ctx, query)
+}
+
+// MockTemplateWriter is a mock of TemplateWriter interface.
 type MockTemplateWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockTemplateWriterMockRecorder
 }
 
-// MockTemplateWriterMockRecorder is the mock recorder for MockTemplateWriter
+// MockTemplateWriterMockRecorder is the mock recorder for MockTemplateWriter.
 type MockTemplateWriterMockRecorder struct {
 	mock *MockTemplateWriter
 }
 
-// NewMockTemplateWriter creates a new mock instance
+// NewMockTemplateWriter creates a new mock instance.
 func NewMockTemplateWriter(ctrl *gomock.Controller) *MockTemplateWriter {
 	mock := &MockTemplateWriter{ctrl: ctrl}
 	mock.recorder = &MockTemplateWriterMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTemplateWriter) EXPECT() *MockTemplateWriterMockRecorder {
 	return m.recorder
 }
 
-// CreateTemplate mocks base method
+// CreateTemplate mocks base method.
 func (m *MockTemplateWriter) CreateTemplate(ctc context.Context, template *v1.Template) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTemplate", ctc, template)
@@ -3764,13 +3807,41 @@ func (m *MockTemplateWriter) CreateTemplate(ctc context.Context, template *v1.Te
 	return ret0, ret1
 }
 
-// CreateTemplate indicates an expected call of CreateTemplate
+// CreateTemplate indicates an expected call of CreateTemplate.
 func (mr *MockTemplateWriterMockRecorder) CreateTemplate(ctc, template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).CreateTemplate), ctc, template)
 }
 
-// UpdateTemplate mocks base method
+// DeleteTemplate mocks base method.
+func (m *MockTemplateWriter) DeleteTemplate(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplate indicates an expected call of DeleteTemplate.
+func (mr *MockTemplateWriterMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplate), ctx, name)
+}
+
+// DeleteTemplateCollection mocks base method.
+func (m *MockTemplateWriter) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection.
+func (mr *MockTemplateWriterMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplateCollection), ctx, query)
+}
+
+// UpdateTemplate mocks base method.
 func (m *MockTemplateWriter) UpdateTemplate(ctx context.Context, template *v1.Template) (*v1.Template, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTemplate", ctx, template)
@@ -3779,36 +3850,8 @@ func (m *MockTemplateWriter) UpdateTemplate(ctx context.Context, template *v1.Te
 	return ret0, ret1
 }
 
-// UpdateTemplate indicates an expected call of UpdateTemplate
+// UpdateTemplate indicates an expected call of UpdateTemplate.
 func (mr *MockTemplateWriterMockRecorder) UpdateTemplate(ctx, template interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).UpdateTemplate), ctx, template)
-}
-
-// DeleteTemplate mocks base method
-func (m *MockTemplateWriter) DeleteTemplate(ctx context.Context, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplate", ctx, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplate indicates an expected call of DeleteTemplate
-func (mr *MockTemplateWriterMockRecorder) DeleteTemplate(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplate", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplate), ctx, name)
-}
-
-// DeleteTemplateCollection mocks base method
-func (m *MockTemplateWriter) DeleteTemplateCollection(ctx context.Context, query *query.Query) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTemplateCollection", ctx, query)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteTemplateCollection indicates an expected call of DeleteTemplateCollection
-func (mr *MockTemplateWriterMockRecorder) DeleteTemplateCollection(ctx, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTemplateCollection", reflect.TypeOf((*MockTemplateWriter)(nil).DeleteTemplateCollection), ctx, query)
 }

--- a/pkg/server/registry/cronbackup/strategy.go
+++ b/pkg/server/registry/cronbackup/strategy.go
@@ -66,7 +66,9 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 func SelectableFields(obj *v1.CronBackup) fields.Set {
-	return generic.ObjectMetaFieldsSet(&obj.ObjectMeta, false)
+	return generic.AddObjectMetaFieldsSet(fields.Set{
+		"spec.clusterName": obj.Spec.ClusterName,
+	}, &obj.ObjectMeta, false)
 }
 
 func MatchCronBackup(label labels.Selector, field fields.Selector) storage.SelectionPredicate {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -407,12 +407,13 @@ func SetupController(mgr manager.Manager, informerFactory informers.SharedInform
 		return err
 	}
 	if err = (&clustercontroller.ClusterReconciler{
-		CmdDelivery:     mgr.GetCmdDelivery(),
-		ClusterLister:   informerFactory.Core().V1().Clusters().Lister(),
-		NodeLister:      informerFactory.Core().V1().Nodes().Lister(),
-		NodeWriter:      clusterOperator,
-		ClusterWriter:   clusterOperator,
-		OperationWriter: opOperator,
+		CmdDelivery:      mgr.GetCmdDelivery(),
+		ClusterLister:    informerFactory.Core().V1().Clusters().Lister(),
+		NodeLister:       informerFactory.Core().V1().Nodes().Lister(),
+		NodeWriter:       clusterOperator,
+		ClusterWriter:    clusterOperator,
+		OperationWriter:  opOperator,
+		CronBackupWriter: clusterOperator,
 	}).SetupWithManager(mgr, informerFactory); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Liucw <liu.chuwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Cron backups are not deleted when the cluster is deleted.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeclipper-labs/kubeclipper/issues/68

### Special notes for reviewers:
```
@x893675 @zhuzhenfan 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```