### PR TITLE
fix: add ip detect precheck

### DIFF
--- a/cmd/kcctl/app/options/options.go
+++ b/cmd/kcctl/app/options/options.go
@@ -28,8 +28,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/kubeclipper/kubeclipper/pkg/utils/autodetection"
-
 	"github.com/kubeclipper/kubeclipper/pkg/cli/utils"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/sliceutil"
 
@@ -232,7 +230,6 @@ func NewDeployOptions() *DeployConfig {
 			DataDir:     "/var/lib/kc-etcd",
 		},
 		Debug:            false,
-		IPDetect:         autodetection.MethodFirst,
 		DefaultRegion:    "default",
 		ServerPort:       8080,
 		StaticServerPort: 8081,

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -370,6 +370,9 @@ func (d *DeployOptions) preCheck() bool {
 	if !sudo.PreCheck("sudo", d.deployConfig.SSHConfig, d.IOStreams, d.allNodes) {
 		return false
 	}
+	if !sudo.MultiNIC("ipDetect", d.deployConfig.SSHConfig, d.IOStreams, d.deployConfig.AgentRegions.ListIP(), d.deployConfig.IPDetect) {
+		return false
+	}
 	return true
 }
 

--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -142,8 +142,7 @@ func (c *JoinOptions) preCheck() bool {
 			return false
 		}
 	}
-
-	return true
+	return sudo.MultiNIC("ipDetect", c.deployConfig.SSHConfig, c.IOStreams, c.agentRegion.ListIP(), c.ipDetect)
 }
 
 func (c *JoinOptions) Complete() error {


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

### What this PR does / why we need it:
add ip detect precheck, print a hint if the node has multi nic but --ip-detect not specified.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
use cmd ip a|grep ": "|awk {'print $2'}|sed 's/://' to print ifaces.
filter logic iface, if > 1,print a hint.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```