### PR TITLE
unnecessary /kc/configs directory

### DIFF
--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -706,7 +706,6 @@ func (d *DeployOptions) getKcAgentConfigTemplateContent(region string) string {
 func (d *DeployOptions) deployKcServer() {
 	cmdList := []string{
 		"mkdir -pv /etc/kubeclipper-server",
-		//sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/configs/*.json /etc/kubeclipper-server/", config.DefaultPkgPath)),
 		sshutils.WrapEcho(config.KcServerService, "/usr/lib/systemd/system/kc-server.service"),
 		fmt.Sprintf("mkdir -pv %s ", d.deployConfig.StaticServerPath),
 		sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/resource/* %s/", config.DefaultPkgPath, d.deployConfig.StaticServerPath)),

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -706,7 +706,7 @@ func (d *DeployOptions) getKcAgentConfigTemplateContent(region string) string {
 func (d *DeployOptions) deployKcServer() {
 	cmdList := []string{
 		"mkdir -pv /etc/kubeclipper-server",
-		sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/configs/*.json /etc/kubeclipper-server/", config.DefaultPkgPath)),
+		//sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/configs/*.json /etc/kubeclipper-server/", config.DefaultPkgPath)),
 		sshutils.WrapEcho(config.KcServerService, "/usr/lib/systemd/system/kc-server.service"),
 		fmt.Sprintf("mkdir -pv %s ", d.deployConfig.StaticServerPath),
 		sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/resource/* %s/", config.DefaultPkgPath, d.deployConfig.StaticServerPath)),


### PR DESCRIPTION
Signed-off-by: Xvv-v <xu.jingwen@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```