### PR TITLE
fix: adding nodes and loading CNI images in the K8S cluster

### DIFF
--- a/pkg/apis/core/v1/registry.go
+++ b/pkg/apis/core/v1/registry.go
@@ -21,8 +21,9 @@ package v1
 import (
 	"net/http"
 
-	"github.com/kubeclipper/kubeclipper/pkg/server/runtime"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubeclipper/kubeclipper/pkg/server/runtime"
 
 	"github.com/kubeclipper/kubeclipper/pkg/models/cluster"
 
@@ -33,12 +34,13 @@ import (
 
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"github.com/kubeclipper/kubeclipper/pkg/models"
 	"github.com/kubeclipper/kubeclipper/pkg/models/operation"
 	"github.com/kubeclipper/kubeclipper/pkg/query"
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	"github.com/kubeclipper/kubeclipper/pkg/service"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var GroupVersion = schema.GroupVersion{Group: corev1.GroupName, Version: "v1"}

--- a/pkg/apis/core/v1/schema.go
+++ b/pkg/apis/core/v1/schema.go
@@ -173,7 +173,7 @@ func (p *PatchNodes) makeWorkerOperation(extra component.ExtraMetadata, cluster 
 		op.Steps = append(op.Steps, steps...)
 
 		// join component
-		steps, err = p.makeWorkerNodeSteps(&extra, cluster, corev1.ActionInstall)
+		steps, err = p.makeWorkerNodeSteps(&extra, cluster, stepNodes, corev1.ActionInstall)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +187,7 @@ func (p *PatchNodes) makeWorkerOperation(extra component.ExtraMetadata, cluster 
 		action = corev1.ActionUninstall
 		op.Labels[common.LabelOperationAction] = corev1.OperationRemoveNodes
 
-		steps, err := p.makeWorkerNodeSteps(&extra, cluster, corev1.ActionUninstall)
+		steps, err := p.makeWorkerNodeSteps(&extra, cluster, stepNodes, corev1.ActionUninstall)
 		if err != nil {
 			return nil, err
 		}
@@ -227,10 +227,10 @@ func (p *PatchNodes) getPackageSteps(cluster *corev1.Cluster, action corev1.Step
 	return nil, fmt.Errorf("packageSteps no support action: %s", action)
 }
 
-func (p *PatchNodes) makeWorkerNodeSteps(extra *component.ExtraMetadata, c *corev1.Cluster, action corev1.StepAction) ([]corev1.Step, error) {
+func (p *PatchNodes) makeWorkerNodeSteps(extra *component.ExtraMetadata, c *corev1.Cluster, patchNodes []corev1.StepNode, action corev1.StepAction) ([]corev1.Step, error) {
 	role := p.Role.String()
 	gen := k8s.GenNode{}
-	err := gen.InitStepper(extra, c, role).MakeSteps(extra, role)
+	err := gen.InitStepper(extra, c, role).MakeSteps(extra, patchNodes, role)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/core/v1/schema_test.go
+++ b/pkg/apis/core/v1/schema_test.go
@@ -81,6 +81,14 @@ var (
 				MTU:               1440,
 			},
 		},
+		Networking: v1.Networking{
+			IPFamily:      v1.IPFamilyIPv4,
+			Services:      v1.NetworkRanges{CIDRBlocks: []string{"10.96.0.0/16"}},
+			Pods:          v1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/24"}},
+			DNSDomain:     "cluster.local",
+			ProxyMode:     "ipvs",
+			WorkerNodeVip: "169.254.169.100",
+		},
 	}
 	master = v1.WorkerNodeList{
 		{

--- a/pkg/controller/cluster_status.go
+++ b/pkg/controller/cluster_status.go
@@ -30,13 +30,14 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/labels"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	listerv1 "github.com/kubeclipper/kubeclipper/pkg/client/lister/core/v1"
 	"github.com/kubeclipper/kubeclipper/pkg/component"
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/manager"
 	"github.com/kubeclipper/kubeclipper/pkg/logger"
 	"github.com/kubeclipper/kubeclipper/pkg/models/cluster"
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #90 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```