### PR TITLE
add refresh token expires in login response

### DIFF
--- a/pkg/authentication/auth/token.go
+++ b/pkg/authentication/auth/token.go
@@ -71,10 +71,11 @@ func (t *tokenOperator) IssueTo(user user.Info) (*oauth.Token, error) {
 	}
 
 	result := &oauth.Token{
-		AccessToken:  accessToken,
-		TokenType:    "Bearer",
-		RefreshToken: refreshToken,
-		ExpiresIn:    int(accessTokenExpiresIn.Seconds()),
+		AccessToken:      accessToken,
+		TokenType:        "Bearer",
+		RefreshToken:     refreshToken,
+		ExpiresIn:        int(accessTokenExpiresIn.Seconds()),
+		RefreshExpiresIn: int(refreshTokenExpiresIn.Seconds()),
 	}
 
 	if !t.options.MultipleLogin {

--- a/pkg/authentication/oauth/oauth_options.go
+++ b/pkg/authentication/oauth/oauth_options.go
@@ -61,6 +61,9 @@ type Token struct {
 
 	// ExpiresIn is the optional expiration second of the access token.
 	ExpiresIn int `json:"expires_in,omitempty"`
+
+	// RfreshExpiresIn is the optional expiration second of the refresh token.
+	RefreshExpiresIn int `json:"refresh_expires_in,omitempty"`
 }
 
 type Options struct {

--- a/pkg/authentication/oauth/oauth_options.go
+++ b/pkg/authentication/oauth/oauth_options.go
@@ -62,7 +62,7 @@ type Token struct {
 	// ExpiresIn is the optional expiration second of the access token.
 	ExpiresIn int `json:"expires_in,omitempty"`
 
-	// RfreshExpiresIn is the optional expiration second of the refresh token.
+	// RefreshExpiresIn is the optional expiration second of the refresh token.
 	RefreshExpiresIn int `json:"refresh_expires_in,omitempty"`
 }
 


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind optimize

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #123 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```