### PR TITLE
fix: cluster upgrade

### DIFF
--- a/pkg/scheme/core/v1/k8s/cluster.go
+++ b/pkg/scheme/core/v1/k8s/cluster.go
@@ -230,6 +230,10 @@ func (stepper *Upgrade) InitSteps(ctx context.Context) error {
 					Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, upgradePackage, version, component.TypeStep),
 					CustomCommand: masterDownload,
 				},
+				{
+					Type:         v1.CommandShell,
+					ShellCommand: []string{"chmod", "+x", "/usr/bin/kubelet-pre-start.sh", "/usr/bin/kubelet", "/usr/bin/kubeadm", "/usr/bin/kubectl", "/usr/bin/conntrack"},
+				},
 			},
 			RetryTimes: 1,
 		}}
@@ -252,6 +256,10 @@ func (stepper *Upgrade) InitSteps(ctx context.Context) error {
 					Type:          v1.CommandCustom,
 					Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, upgradePackage, version, component.TypeStep),
 					CustomCommand: workerDownload,
+				},
+				{
+					Type:         v1.CommandShell,
+					ShellCommand: []string{"chmod", "+x", "/usr/bin/kubelet-pre-start.sh", "/usr/bin/kubelet", "/usr/bin/kubeadm", "/usr/bin/kubectl", "/usr/bin/conntrack"},
 				},
 			},
 			RetryTimes: 1,


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #140

### Special notes for reviewers:
```
in install step hash chmod,upgrade step forgot.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```