### PR TITLE
add --tags for go cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ build-cli:
 	KUBE_VERBOSE=2 bash hack/make-rules/build.sh cmd/kcctl
 
 build-e2e:
-	go test -c -ldflags "-s -w" -o dist/e2e.test ./test/e2e
+	go test -tags=kc_default -c -ldflags "-s -w" -o dist/e2e.test ./test/e2e
 
 openapi:
-	go run ./tools/doc-gen/main.go
+	go run -tags=kc_default ./tools/doc-gen/main.go
 
 .PHONY:test
 test:
@@ -57,7 +57,7 @@ goimports:
 	@hack/update-goimports.sh
 
 vet:
-	go vet ./pkg/... ./cmd/...
+	go vet -tags=kc_default ./pkg/... ./cmd/...
 
 lint:
 	golangci-lint run --build-tags kc_default --timeout 5m
@@ -65,7 +65,7 @@ lint:
 
 .PHONY: cli cleancli cli-serve
 cli: cleancli
-	go run ./tools/kcctldocs-gen/main.go
+	go run -tags=kc_default ./tools/kcctldocs-gen/main.go
 	docker run -v $(shell pwd)/tools/kcctldocs-gen/generators/includes:/source -v $(shell pwd)/tools/kcctldocs-gen/generators/build:/build -v $(shell pwd)/tools/kcctldocs-gen/generators/:/manifest brianpursley/brodocs:latest
 
 cleancli:


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```