### PR TITLE
fix: deploy with fip.

### DIFF
--- a/pkg/utils/sshutils/sshcmd.go
+++ b/pkg/utils/sshutils/sshcmd.go
@@ -1,0 +1,25 @@
+package sshutils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kubeclipper/kubeclipper/pkg/utils/sliceutil"
+)
+
+func IsFloatIP(sshConfig *SSH, ip string) (bool, error) {
+	// 1.extra all ip
+	result, err := SSHCmd(sshConfig, ip, `ifconfig|grep inet|awk {'print $2'}`)
+	if err != nil {
+		return false, err
+	}
+	if result.ExitCode != 0 {
+		return false, fmt.Errorf("%s stderr:%s", result.Short(), result.Stderr)
+	}
+	ips := strings.Split(result.Stdout, "\n")
+	ips = sliceutil.RemoveString(ips, func(item string) bool {
+		return item == ""
+	})
+	// 2.check
+	return !sliceutil.HasString(ips, ip), nil
+}


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #154

### Special notes for reviewers:
```
when deploy with floatIP,etcd and nats listen on 0.0.0.0
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```