### PR TITLE
fix: update aio deploy without ssh config.

### DIFF
--- a/pkg/cli/drain/drain.go
+++ b/pkg/cli/drain/drain.go
@@ -149,6 +149,9 @@ func (c *DrainOptions) Complete() error {
 }
 
 func (c *DrainOptions) ValidateArgs() error {
+	if c.deployConfig.SSHConfig.PkFile == "" && c.deployConfig.SSHConfig.Password == "" {
+		return fmt.Errorf("one of pkfile or password must be specify,please config it in %s", c.deployConfig.Config)
+	}
 	if c.cliOpts.Config == "" {
 		return errors.New("config path cannot be empty")
 	}

--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -153,7 +153,7 @@ func (c *JoinOptions) Complete() error {
 
 func (c *JoinOptions) ValidateArgs() error {
 	if c.deployConfig.SSHConfig.PkFile == "" && c.deployConfig.SSHConfig.Password == "" {
-		return fmt.Errorf("one of --pk-file or --passwd must be specified,please config it in deploy-config.yaml")
+		return fmt.Errorf("one of pkfile or password must be specify,please config it in %s", c.deployConfig.Config)
 	}
 	if c.ipDetect != "" && !autodetection.CheckMethod(c.ipDetect) {
 		return fmt.Errorf("invalid ip detect method,suppot [first-found,interface=xxx,cidr=xxx] now")

--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -152,6 +152,9 @@ func (c *JoinOptions) Complete() error {
 }
 
 func (c *JoinOptions) ValidateArgs() error {
+	if c.deployConfig.SSHConfig.PkFile == "" && c.deployConfig.SSHConfig.Password == "" {
+		return fmt.Errorf("one of --pk-file or --passwd must be specified,please config it in deploy-config.yaml")
+	}
 	if c.ipDetect != "" && !autodetection.CheckMethod(c.ipDetect) {
 		return fmt.Errorf("invalid ip detect method,suppot [first-found,interface=xxx,cidr=xxx] now")
 	}
@@ -208,13 +211,13 @@ func (c *JoinOptions) preCheckKcAgent(ip string) bool {
 		return false
 	}
 	// check if kc-agent is running
-	ret, err := sshutils.SSHCmdWithSudo(c.deployConfig.SSHConfig, ip, "systemctl --all --type service | grep -Fq kc-agent")
+	ret, err := sshutils.SSHCmdWithSudo(c.deployConfig.SSHConfig, ip, "systemctl --all --type service | grep kc-agent | wc -l")
 	logger.V(2).Info(ret.String())
 	if err != nil {
 		logger.Errorf("check node %s failed: %s", ip, err.Error())
 		return false
 	}
-	if ret.ExitCode == 0 && ret.Stdout != "" {
+	if ret.StdoutToString("") != "0" {
 		logger.Errorf("kc-agent service exist on %s, please clean old environment", ip)
 		return false
 	}

--- a/pkg/cli/proxy/deploy.go
+++ b/pkg/cli/proxy/deploy.go
@@ -117,6 +117,9 @@ func (d *ProxyOptions) Complete() error {
 }
 
 func (d *ProxyOptions) ValidateArgs() error {
+	if d.deployConfig.SSHConfig.PkFile == "" && d.deployConfig.SSHConfig.Password == "" {
+		return fmt.Errorf("one of pkfile or password must be specify,please config it in %s", d.deployConfig.Config)
+	}
 	if d.proxy == "" {
 		return fmt.Errorf("--proxy must be specified")
 	}

--- a/pkg/cli/proxy/tunnel.go
+++ b/pkg/cli/proxy/tunnel.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kubeclipper/kubeclipper/pkg/cli/utils"
 	"github.com/kubeclipper/kubeclipper/pkg/proxy/config"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
 )
 
 func parseTunnel(tunnelsStr []string) ([]tunnel, error) {
@@ -48,9 +48,9 @@ func (d *ProxyOptions) generateProxyConfig() *config.Config {
 	}
 
 	for agentIP, tunnels := range m {
-		name := utils.GetRemoteHostName(d.deployConfig.SSHConfig, agentIP)
+		hostname, _ := sshutils.GetRemoteHostName(d.deployConfig.SSHConfig, agentIP)
 		agentConfig := config.AgentConfig{
-			Name:    name,
+			Name:    hostname,
 			Tunnels: make([]config.Tunnel, 0, len(tunnels)),
 		}
 		for _, v := range tunnels {

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -112,7 +112,6 @@ func NewCmdUpgrade(stream options.IOStreams) *cobra.Command {
 	cmd.Flags().BoolVar(&o.binary, "binary", o.binary, "Upgrade with the specified binary file")
 	cmd.Flags().BoolVar(&o.online, "online", o.online, "upgrade with online package")
 	cmd.Flags().StringVar(&o.version, "version", o.version, "input version or branch name. e.g: v1.12.1 or master、latest")
-	options.AddFlagsToSSH(o.deployConfig.SSHConfig, cmd.Flags())
 
 	return cmd
 }
@@ -138,6 +137,9 @@ func (o *UpgradeOptions) Complete() error {
 func (o *UpgradeOptions) Validate(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		return utils.UsageErrorf(cmd, "You must specify the component of kubeclipper to upgrade, support [ agent | server | etcd | console ] now")
+	}
+	if o.deployConfig.SSHConfig.PkFile == "" && o.deployConfig.SSHConfig.Password == "" {
+		return fmt.Errorf("one of pkfile or password must be specify,please config it in %s", o.deployConfig.Config)
 	}
 	o.component = args[0]
 
@@ -203,7 +205,7 @@ func (o *UpgradeOptions) checkVersion() error {
 	platforms := strings.Split(versionInfo.Platform, "/")
 	o.arch = platforms[1]
 
-	//TODO: check for version compatibility issues
+	// TODO: check for version compatibility issues
 	if ok := m.MatchString(o.version); ok {
 		v := strings.Split(versionInfo.GitVersion[1:], "-")
 		current, _ := strconv.Atoi(strings.Join(strings.Split(v[0], "."), ""))

--- a/pkg/cli/utils/file.go
+++ b/pkg/cli/utils/file.go
@@ -20,19 +20,11 @@ package utils
 
 import (
 	"os"
-	"strings"
-
-	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
 )
 
 func FileExist(path string) bool {
 	_, err := os.Lstat(path)
 	return !os.IsNotExist(err)
-}
-
-func GetRemoteHostName(sshConfig *sshutils.SSH, hostIP string) string {
-	hostName := sshConfig.CmdToString(hostIP, "hostname", "")
-	return strings.ToLower(hostName)
 }
 
 func WriteToFile(filePath string, data []byte) error {
@@ -46,20 +38,4 @@ func WriteToFile(filePath string, data []byte) error {
 		return err
 	}
 	return nil
-}
-
-func RemoveDuplication(arr []string) []string {
-	set := make(map[string]struct{}, len(arr))
-	j := 0
-	for _, v := range arr {
-		_, ok := set[v]
-		if ok {
-			continue
-		}
-		set[v] = struct{}{}
-		arr[j] = v
-		j++
-	}
-
-	return arr[:j]
 }

--- a/pkg/utils/sshutils/cmd_test.go
+++ b/pkg/utils/sshutils/cmd_test.go
@@ -37,3 +37,16 @@ func TestIsFileExistV2(t *testing.T) {
 	}
 	t.Log(exists)
 }
+
+func TestWhoami(t *testing.T) {
+	whoami := Whoami()
+	t.Log(whoami)
+}
+
+func TestRunCmdAsSSH(t *testing.T) {
+	ret, err := RunCmdAsSSH("whoami1")
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log(ret.String())
+}

--- a/pkg/utils/sshutils/scp.go
+++ b/pkg/utils/sshutils/scp.go
@@ -127,6 +127,15 @@ func (ss *SSH) Copy(host, localFilePath, remoteFilePath string) error {
 	if err = ret.Error(); err != nil {
 		return err
 	}
+	// if need run as exec,change to use scp cmd.
+	if SSHToCmd(ss, host) {
+		ret, err = CmdToString("scp", localFilePath, remoteFilePath)
+		if err != nil {
+			return err
+		}
+		return ret.Error()
+	}
+
 	sftpClient, err := ss.sftpConnect(host)
 	if err != nil {
 		logger.Fatalf("[%s]sftp conn failed: %s", host, err)
@@ -196,6 +205,16 @@ func (ss *SSH) download(host, localFilePath, remoteFilePath string) error {
 	if err = ret.Error(); err != nil {
 		return err
 	}
+
+	// if need run as exec,change to use scp cmd.
+	if SSHToCmd(ss, host) {
+		ret, err = CmdToString("scp", remoteFilePath, localFilePath)
+		if err != nil {
+			return err
+		}
+		return ret.Error()
+	}
+
 	sftpClient, err := ss.sftpConnect(host)
 	if err != nil {
 		logger.Fatalf("[%s]sftp conn failed: %s", host, err)

--- a/pkg/utils/sshutils/ssh.go
+++ b/pkg/utils/sshutils/ssh.go
@@ -24,8 +24,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -158,28 +156,6 @@ func (ss *SSH) CmdToString(host, cmd, spilt string) string {
 		return str
 	}
 	return ""
-}
-
-func (ss *SSH) IsFileExist(host, remoteFilePath string) bool {
-	// if remote file is
-	// ls -l | grep aa | wc -l
-	remoteFileName := path.Base(remoteFilePath) // aa
-	remoteFileDirName := path.Dir(remoteFilePath)
-	// it's bug: if file is aa.bak, `ls -l | grep aa | wc -l` is 1 ,should use `ll aa 2>/dev/null |wc -l`
-	// remoteFileCommand := fmt.Sprintf("ls -l %s| grep %s | grep -v grep |wc -l", remoteFileDirName, remoteFileName)
-	remoteFileCommand := fmt.Sprintf("ls -l %s/%s 2>/dev/null |wc -l", remoteFileDirName, remoteFileName)
-
-	data := ss.CmdToString(host, remoteFileCommand, " ")
-	count, err := strconv.Atoi(strings.TrimSpace(data))
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Errorf("[%s] RemoteFileExist:%s", host, err)
-		}
-	}()
-	if err != nil {
-		panic(1)
-	}
-	return count != 0
 }
 
 func (ss *SSH) Cmd(host string, cmd string) []byte {

--- a/pkg/utils/sshutils/ssh2cmd.go
+++ b/pkg/utils/sshutils/ssh2cmd.go
@@ -1,0 +1,23 @@
+package sshutils
+
+import (
+	"os/exec"
+)
+
+// SSHToCmd if caller don't provide enough config for run ssh cmd，change to run cmd by os.exec on localhost.
+// for aio deploy now.
+func SSHToCmd(sshConfig *SSH, host string) bool {
+
+	ret := host == "" ||
+		sshConfig == nil ||
+		sshConfig != nil && sshConfig.User == "" || (sshConfig.Password == "" && sshConfig.PkFile == "")
+	return ret
+}
+
+func ExtraExitCode(err error) (bool, int) {
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		// The program has exited with an exit code != 0
+		return true, exiterr.ExitCode()
+	}
+	return false, -1
+}

--- a/pkg/utils/sshutils/ssh_v2_test.go
+++ b/pkg/utils/sshutils/ssh_v2_test.go
@@ -18,11 +18,17 @@
 
 package sshutils
 
-//const _host = "172.20.151.80"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// const _host = "172.20.151.80"
 //
-////const _host = "172.20.150.220"
+// //const _host = "172.20.150.220"
 //
-//var (
+// var (
 //	_defaultTimeout = time.Duration(1) * time.Minute
 //	sshConfig       = &SSH{
 //		User:              "root",
@@ -34,17 +40,17 @@ package sshutils
 //		Password:          "root",
 //		ConnectionTimeout: &_defaultTimeout,
 //	}
-//)
+// )
 //
-//func TestSSHCmd(t *testing.T) {
+// func TestSSHCmd(t *testing.T) {
 //	result, err := SSHCmd(sshConfig, _host, "ls")
 //	if err != nil {
 //		t.Fatal(err)
 //	}
 //	t.Log(result)
-//}
+// }
 //
-//func TestCmdPatch(t *testing.T) {
+// func TestCmdPatch(t *testing.T) {
 //	walk := func(result Result, err error) error {
 //		t.Log(result)
 //		t.Log("err: ", err)
@@ -72,4 +78,36 @@ package sshutils
 //		t.Fatal(err)
 //	}
 //	t.Log("cmd run success")
-//}
+// }
+
+func TestSSHCmd(t *testing.T) {
+	defer func() {
+		Cmd("rm", "/tmp/d.txt")
+		Cmd("rm", "/tmp/dd.txt")
+	}()
+	ret, err := SSHCmd(nil, "", "bash -c \"echo 123\"")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "123", ret.StdoutToString(""))
+
+	_, err = SSHCmd(nil, "", WrapEcho("12345", "/tmp/d.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret, err = RunCmdAsSSH("cat /tmp/d.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "12345", ret.StdoutToString(""))
+
+	_, err = SSHCmdWithSudo(nil, "", WrapEcho("54321", "/tmp/dd.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ret, err = RunCmdAsSSH("cat /tmp/dd.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "54321", ret.StdoutToString(""))
+}

--- a/pkg/utils/sshutils/sshcmd.go
+++ b/pkg/utils/sshutils/sshcmd.go
@@ -23,3 +23,11 @@ func IsFloatIP(sshConfig *SSH, ip string) (bool, error) {
 	// 2.check
 	return !sliceutil.HasString(ips, ip), nil
 }
+
+func GetRemoteHostName(sshConfig *SSH, hostIP string) (string, error) {
+	result, err := SSHCmd(sshConfig, hostIP, "hostname")
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(result.StdoutToString("")), nil
+}


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
update aio deploy without ssh config
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #122

### Special notes for reviewers:
```
if user don't provide enough config for run ssh cmd,change to run cmd by os.exec on localhost.
and filecopy method from`github.com/pkg/sftp`lib change to  scp. 
remove some unused code.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```