### PR TITLE
fix: kcctl resource remove unnecessary ssh parmeter.

### DIFF
--- a/pkg/cli/clean/clean.go
+++ b/pkg/cli/clean/clean.go
@@ -50,7 +50,6 @@ const (
   kcctl clean
   kcctl clean --config ~/.kc/deploy-config.yaml
 
-
   # Specify the deploy-config.yaml path
   kcctl clean --config ~/.kc/deploy-config.yaml -A
 

--- a/pkg/cli/create/create.go
+++ b/pkg/cli/create/create.go
@@ -34,8 +34,14 @@ const (
   Using the create command to create cluster, user, or role resources.
   Or you can choose to create those directly from a file.`
 	createExample = `
-  # Using config file to create resource
-  kcctl create -f 'FILE-PATH'`
+  # Create cluster offline. The default value of offline is true, so it can be omitted.
+  kcctl create cluster --name demo --master 192.168.10.123
+
+  # Create role has permission to view cluster
+  kcctl create role --name cluster_viewer --rules=role-template-view-clusters
+
+  # Create user with required parameters
+  kcctl create user --name simple-user --role=platform-view --password 123456 --phone 10086 --email simple@example.com`
 )
 
 type BaseOptions struct {
@@ -65,13 +71,11 @@ func NewCmdCreate(streams options.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "create (--filename | -f <FILE-NAME>)",
 		DisableFlagsInUseLine: true,
-		Short:                 "create kubeclipper resource",
+		Short:                 "Create kubeclipper resource",
 		Long:                  longDescription,
 		Example:               createExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			utils.CheckErr(o.Complete(o.CliOpts))
-			// utils.CheckErr(o.ValidateArgs(cmd, args))
-			// utils.CheckErr(o.RunGet())
 		},
 	}
 	cmd.Flags().StringVarP(&o.Filename, "filename", "f", "", "use resource file to create")

--- a/pkg/cli/delete/delete.go
+++ b/pkg/cli/delete/delete.go
@@ -74,7 +74,7 @@ func NewCmdDelete(streams options.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "delete (<cluster> | <user> | <role>) [flags]",
 		DisableFlagsInUseLine: true,
-		Short:                 "delete kubeclipper resource",
+		Short:                 "Delete kubeclipper resource",
 		Long:                  longDescription,
 		Example:               deleteExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/drain/drain.go
+++ b/pkg/cli/drain/drain.go
@@ -84,7 +84,7 @@ func NewCmdDrain(streams options.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "drain (--agent <agentIps>) [flags]",
 		DisableFlagsInUseLine: true,
-		Short:                 "drain kubeclipper server or agent",
+		Short:                 "Drain kubeclipper agent node",
 		Long:                  longDescription,
 		Example:               drainExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/get/get.go
+++ b/pkg/cli/get/get.go
@@ -94,7 +94,7 @@ func NewCmdGet(streams options.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "get [(-o|--output=)table|json|yaml] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags]",
 		DisableFlagsInUseLine: true,
-		Short:                 "Display one or many resources",
+		Short:                 "Display one or multiple resources",
 		Long:                  longDescription,
 		Example:               getExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -100,7 +100,7 @@ func NewCmdJoin(streams options.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "join [flags]",
 		DisableFlagsInUseLine: true,
-		Short:                 "join kubeclipper agent and server node",
+		Short:                 "Join kubeclipper agent node",
 		Long:                  longDescription,
 		Example:               joinExample,
 		Args:                  cobra.NoArgs,

--- a/pkg/cli/login/login.go
+++ b/pkg/cli/login/login.go
@@ -52,6 +52,7 @@ const (
 	loginExample = `
   # Login to the kubeclipper server
   kcctl login --host http://127.0.0.1 --username root
+
   # Login to the kubeclipper server via passwd by cli
   kcctl login --host http://127.0.0.1 --username root --password xxx
 

--- a/pkg/cli/registry/registry.go
+++ b/pkg/cli/registry/registry.go
@@ -170,7 +170,7 @@ func NewCmdRegistry(streams options.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "registry",
 		DisableFlagsInUseLine: true,
-		Short:                 "registry operation",
+		Short:                 "Registry operation",
 		Long:                  longDescription,
 		Example:               registryExample,
 		Args:                  cobra.NoArgs,

--- a/pkg/cli/resource/resource_test.go
+++ b/pkg/cli/resource/resource_test.go
@@ -74,7 +74,6 @@ func TestResourceOptions_parsePackageName(t *testing.T) {
 			o := &ResourceOptions{
 				IOStreams:    tt.fields.IOStreams,
 				PrintFlags:   tt.fields.PrintFlags,
-				SSHConfig:    tt.fields.SSHConfig,
 				DeployConfig: tt.fields.DeployConfig,
 				deployConfig: tt.fields.deployConfig,
 				List:         tt.fields.List,


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
kcctl resource cmd remove unnecessary ssh parameter,load from deploy-config.yaml
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```