### PR TITLE
update cron schedule parse and unit test

### DIFF
--- a/pkg/controller/cronbackupcontroller/controller.go
+++ b/pkg/controller/cronbackupcontroller/controller.go
@@ -67,6 +67,7 @@ type CronBackupReconciler struct {
 	CronBackupLister  listerv1.CronBackupLister
 	CronBackupWriter  cluster.CronBackupWriter
 	CmdDelivery       service.CmdDelivery
+	Now               func() time.Time
 }
 
 func (r *CronBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -92,7 +93,7 @@ func (r *CronBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	now := metav1.NewTime(time.Now())
+	now := metav1.NewTime(r.Now())
 	if cronBackup.Spec.RunAt != nil {
 		// first created cron backup, update next schedule time
 		if cronBackup.Status.NextScheduleTime == nil {
@@ -129,7 +130,7 @@ func (r *CronBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if cronBackup.Spec.Schedule != "" {
 		// first created cron backup, update next schedule time
 		if cronBackup.Status.NextScheduleTime == nil {
-			schedule := parseSchedule(cronBackup.Spec.Schedule)
+			schedule := r.parseSchedule(cronBackup.Spec.Schedule)
 			s, _ := cron.NewParser(4 | 8 | 16 | 32 | 64).Parse(schedule)
 			// update the next schedule time
 			nextRunAt := metav1.NewTime(s.Next(time.Now()))
@@ -157,7 +158,7 @@ func (r *CronBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			cronBackup.Status.LastScheduleTime = &now
 			cronBackup.Status.LastSuccessfulTime = cronBackup.Status.LastScheduleTime
 
-			schedule := parseSchedule(cronBackup.Spec.Schedule)
+			schedule := r.parseSchedule(cronBackup.Spec.Schedule)
 			s, _ := cron.NewParser(4 | 8 | 16 | 32 | 64).Parse(schedule)
 			// update the next schedule time
 			nextRunAt := metav1.NewTime(s.Next(now.Time))
@@ -539,21 +540,14 @@ func (r *CronBackupReconciler) deleteBackup(log logger.Logging, clusterName stri
 	return nil
 }
 
-func parseSchedule(schedule string) string {
-	year := time.Now().Year()
+func (s *CronBackupReconciler) parseSchedule(schedule string) string {
+	currentTime := s.Now()
 	arr := strings.Split(schedule, " ")
 	if arr[2] == "L" {
-		switch time.Now().Month() {
-		case 1, 3, 5, 7, 8, 10, 12:
-			return strings.Replace(schedule, "L", "31", 1)
-		case 4, 6, 9, 11:
-			return strings.Replace(schedule, "L", "30", 1)
-		case 2:
-			if (year%4 == 0 && year%100 != 0) || year%400 == 0 {
-				return strings.Replace(schedule, "L", "28", 1)
-			}
-			return strings.Replace(schedule, "L", "29", 1)
-		}
+		first := currentTime.AddDate(0, 0, -currentTime.Day()+1)
+		next := first.AddDate(0, 1, -1)
+		lastDay := strconv.Itoa(next.Day())
+		return strings.Replace(schedule, "L", lastDay, 1)
 	}
 	return schedule
 }

--- a/pkg/controller/cronbackupcontroller/controller.go
+++ b/pkg/controller/cronbackupcontroller/controller.go
@@ -540,8 +540,8 @@ func (r *CronBackupReconciler) deleteBackup(log logger.Logging, clusterName stri
 	return nil
 }
 
-func (s *CronBackupReconciler) parseSchedule(schedule string) string {
-	currentTime := s.Now()
+func (r *CronBackupReconciler) parseSchedule(schedule string) string {
+	currentTime := r.Now()
 	arr := strings.Split(schedule, " ")
 	if arr[2] == "L" {
 		first := currentTime.AddDate(0, 0, -currentTime.Day()+1)

--- a/pkg/controller/cronbackupcontroller/controller_test.go
+++ b/pkg/controller/cronbackupcontroller/controller_test.go
@@ -1,36 +1,108 @@
 package cronbackupcontroller
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+	"time"
+)
 
-func Test_parseSchedule(t *testing.T) {
+func TestCronBackupReconciler_parseSchedule(t *testing.T) {
+	type fields struct {
+		Now func() time.Time
+	}
 	type args struct {
 		schedule string
 	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
+	type spec struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}
+
+	var generateIntercalaryYearSpec = func() []spec {
+		specs := make([]spec, 366)
+		date := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		for i := 0; i < len(specs); i++ {
+			t := date
+			specs[i].fields.Now = func() time.Time {
+				return t
+			}
+			specs[i].args = args{
+				schedule: "0 0 L * *",
+			}
+			specs[i].want = generateWant(366, specs[i].fields.Now().Month())
+			specs[i].name = fmt.Sprintf("day %s", specs[i].fields.Now().String())
+			date = date.AddDate(0, 0, 1)
+		}
+		return specs
+	}
+
+	var generateNormalYearSpec = func() []spec {
+		specs := make([]spec, 365)
+		date := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+		for i := 0; i < len(specs); i++ {
+			t := date
+			specs[i].fields.Now = func() time.Time {
+				return t
+			}
+			specs[i].args = args{
+				schedule: "0 0 L * *",
+			}
+			specs[i].want = generateWant(365, specs[i].fields.Now().Month())
+			specs[i].name = fmt.Sprintf("day %s", specs[i].fields.Now().String())
+			date = date.AddDate(0, 0, 1)
+		}
+		return specs
+	}
+
+	var tests []spec
+	tests = append(tests, generateNormalYearSpec()...)
+	tests = append(tests, generateIntercalaryYearSpec()...)
+	tests = append(tests, []spec{
 		{
-			name: "test parse cron schedule without day of month is 'L'",
+			name: "without day of month synax 'L'",
+			fields: fields{
+				Now: func() time.Time {
+					return time.Now()
+				},
+			},
 			args: args{
 				schedule: "0 0 1 * *",
 			},
 			want: "0 0 1 * *",
 		},
-		{
-			name: "test parse cron schedule with day of month is 'L'",
-			args: args{
-				schedule: "0 0 L * *",
-			},
-			want: "0 0 31 * *",
-		},
-	}
+	}...)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := parseSchedule(tt.args.schedule); got != tt.want {
-				t.Errorf("parseSchedule() = %v, want %v", got, tt.want)
+			s := &CronBackupReconciler{
+				Now: tt.fields.Now,
+			}
+			if got := s.parseSchedule(tt.args.schedule); got != tt.want {
+				t.Errorf("CronBackupReconciler.parseSchedule() = %v, want %v, %v", got, tt.want, tt.fields.Now().String())
 			}
 		})
 	}
+}
+
+func generateWant(days int, month time.Month) string {
+	if days == 365 {
+		switch month {
+		case time.January, time.March, time.May, time.July, time.August, time.October, time.December:
+			return "0 0 31 * *"
+		case time.April, time.June, time.September, time.November:
+			return "0 0 30 * *"
+		case time.February:
+			return "0 0 28 * *"
+		}
+	}
+	switch month {
+	case time.January, time.March, time.May, time.July, time.August, time.October, time.December:
+		return "0 0 31 * *"
+	case time.April, time.June, time.September, time.November:
+		return "0 0 30 * *"
+	case time.February:
+		return "0 0 29 * *"
+	}
+	panic("unexpected")
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/kubeclipper/kubeclipper/pkg/controller/cronbackupcontroller"
 
@@ -428,6 +429,7 @@ func SetupController(mgr manager.Manager, informerFactory informers.SharedInform
 		ClusterWriter:     clusterOperator,
 		CronBackupWriter:  clusterOperator,
 		BackupWriter:      clusterOperator,
+		Now:               time.Now,
 	}).SetupWithManager(mgr, informerFactory); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Liucw <liu.chuwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
update the way to parse month-end cron schedule

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeclipper-labs/kubeclipper/issues/177

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 