### PR TITLE
Failed to update the K8S cluster certificate

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -493,7 +493,7 @@ func (h *handler) UpdateClusterCertification(request *restful.Request, response 
 		restplus.HandleBadRequest(response, request, err)
 		return
 	}
-	op, err := h.parseUpdateCertOperation(extraMeta)
+	op, err := h.parseUpdateCertOperation(c, extraMeta)
 	if err != nil {
 		restplus.HandleBadRequest(response, request, err)
 		return

--- a/pkg/apis/core/v1/utils.go
+++ b/pkg/apis/core/v1/utils.go
@@ -364,11 +364,11 @@ func getActBackupStep(c *v1.Cluster, b *v1.Backup, bp *v1.BackupPoint, pNode *v1
 	return actBackup.GetStep(action), nil
 }
 
-func (h *handler) parseUpdateCertOperation(extraMetadata *component.ExtraMetadata) (*v1.Operation, error) {
+func (h *handler) parseUpdateCertOperation(clu *v1.Cluster, extraMetadata *component.ExtraMetadata) (*v1.Operation, error) {
 	cert := &k8s.Certification{}
 	op := &v1.Operation{}
 	nodes := utils.UnwrapNodeList(extraMetadata.Masters)
-	op.Steps, _ = cert.InstallSteps(nodes)
+	op.Steps, _ = cert.InstallSteps(clu, nodes)
 	return op, nil
 }
 

--- a/pkg/controller/cluster_status.go
+++ b/pkg/controller/cluster_status.go
@@ -153,7 +153,7 @@ func (s *ClusterStatusMon) updateClusterCertification(clusterName string) {
 		return
 	}
 	var cmd []string
-	if clu.KubernetesVersion[1:] < k8s.K8sVersion {
+	if clu.KubernetesVersion[1:] < k8s.KubeCertsCluVersion {
 		cmd = []string{"kubeadm", "alpha", "certs", "check-expiration"}
 	} else {
 		cmd = []string{"kubeadm", "certs", "check-expiration"}

--- a/pkg/controller/cluster_status.go
+++ b/pkg/controller/cluster_status.go
@@ -22,10 +22,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/k8s"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/k8s"
 
 	"github.com/kubeclipper/kubeclipper/pkg/service"
 
@@ -42,7 +44,6 @@ import (
 
 const (
 	clusterStatusMonitorPeriod = 3 * time.Minute
-	k8sVersion                 = 12000
 )
 
 type ClusterStatusMon struct {

--- a/pkg/scheme/core/v1/k8s/kubeadm_step.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_step.go
@@ -48,7 +48,8 @@ const (
 	container       = "container"
 	kubectl         = "kubectl"
 	kubectlTerminal = "kubectlTerminal"
-	K8sVersion      = "1.20"
+	//KubeCertsCluVersion the version that kubeadm certs command appears
+	KubeCertsCluVersion = "1.20"
 )
 
 type Runnable v1.Cluster
@@ -751,7 +752,7 @@ func (stepper *Certification) InitStepper() *Certification {
 
 func (stepper *Certification) InstallSteps(clu *v1.Cluster, nodes []v1.StepNode) ([]v1.Step, error) {
 	var cmd []string
-	if clu.KubernetesVersion[1:] < K8sVersion {
+	if clu.KubernetesVersion[1:] < KubeCertsCluVersion {
 		cmd = []string{"kubeadm", "alpha", "certs", "renew", "all"}
 	} else {
 		cmd = []string{"kubeadm", "certs", "renew", "all"}


### PR DESCRIPTION
Signed-off-by: Xvv-v <xu.jingwen@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #114 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```