### PR TITLE
ctr image import added --all-platforms flags

### DIFF
--- a/pkg/component/utils/utils.go
+++ b/pkg/component/utils/utils.go
@@ -42,13 +42,15 @@ func LoadImage(ctx context.Context, dryRun bool, file, criType string) error {
 
 	switch criType {
 	case "containerd":
-		// docker load -i xxx/images.tar
-		_, err = cmdutil.RunCmdWithContext(ctx, dryRun, "ctr", "--namespace", "k8s.io", "image", "import", file)
+		// ctr --namespace k8s.io image import --all-platforms xxx/images.tar
+		// Why need set `--all-platforms` flag?
+		// This prevents unexpected errors due to the incorrect schema type declaration of the mirroring system that cannot be imported normally.
+		_, err = cmdutil.RunCmdWithContext(ctx, dryRun, "ctr", "--namespace", "k8s.io", "image", "import", "--all-platforms", file)
 		if err != nil {
 			return err
 		}
 	case "docker":
-		// ctr --namespace k8s.io  image import xxx/images.tar
+		// docker load -i xxx/images.tar
 		_, err = cmdutil.RunCmdWithContext(ctx, dryRun, "docker", "load", "-i", file)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #203 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```