### PR TITLE
add kcctl conection port configurable

### DIFF
--- a/cmd/kcctl/app/options/options.go
+++ b/cmd/kcctl/app/options/options.go
@@ -315,7 +315,7 @@ func (c *DeployConfig) Complete() error {
 		return nil
 	}
 
-	if c.SSHConfig.Port != 22 {
+	if c.SSHConfig.Port != DefaultSSHPort {
 		port = c.SSHConfig.Port
 	}
 

--- a/cmd/kcctl/app/options/options.go
+++ b/cmd/kcctl/app/options/options.go
@@ -65,7 +65,6 @@ const (
 	DefaultDeployConfig       = "deploy-config.yaml"
 	DefaultConfig             = "config"
 	DefaultCaPath             = "pki"
-	DefaultSSHPort            = 22
 	DefaultEtcdPKIPath        = "pki/etcd"
 	DefaultNatsPKIPath        = "pki/nats"
 	DefaultKcServerConfigPath = "/etc/kubeclipper-server"
@@ -269,7 +268,7 @@ func NewDeployOptions() *DeployConfig {
 		IPDetect: autodetection.MethodFirst,
 		SSHConfig: &sshutils.SSH{
 			User: "root",
-			Port: DefaultSSHPort,
+			Port: 22,
 		},
 		EtcdConfig: &Etcd{
 			ClientPort:  2379,
@@ -310,13 +309,8 @@ func (c *DeployConfig) MergeDeployOptions() {
 }
 
 func (c *DeployConfig) Complete() error {
-	port := 0
 	if c.Config == "" {
 		return nil
-	}
-
-	if c.SSHConfig.Port != DefaultSSHPort {
-		port = c.SSHConfig.Port
 	}
 
 	if !utils.FileExist(c.Config) {
@@ -344,12 +338,6 @@ func (c *DeployConfig) Complete() error {
 			metadata.Region = c.DefaultRegion
 			c.Agents[ip] = metadata
 		}
-	}
-
-	if port != 0 {
-		c.SSHConfig.Port = port
-	} else if c.SSHConfig.Port == 0 {
-		c.SSHConfig.Port = DefaultSSHPort
 	}
 
 	return nil

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -219,6 +219,9 @@ func (d *DeployOptions) ValidateArgs() error {
 	if !d.aio && d.deployConfig.SSHConfig.PkFile == "" && d.deployConfig.SSHConfig.Password == "" {
 		return fmt.Errorf("one of --pk-file or --passwd must be specified")
 	}
+	if d.deployConfig.SSHConfig.Port <= 0 {
+		return fmt.Errorf("ssh connection port must be a positive number")
+	}
 	if len(d.deployConfig.ServerIPs) == 0 {
 		return fmt.Errorf("must specify at least one server")
 	}

--- a/pkg/utils/sshutils/ssh.go
+++ b/pkg/utils/sshutils/ssh.go
@@ -35,6 +35,7 @@ import (
 type SSH struct {
 	User              string         `json:"user" yaml:"user,omitempty"`
 	Password          string         `json:"password" yaml:"password,omitempty"`
+	Port              int            `json:"port" yaml:"port,omitempty"`
 	PkFile            string         `json:"pkFile" yaml:"pkFile,omitempty"`
 	PkPassword        string         `json:"pkPassword" yaml:"pkPassword,omitempty"`
 	ConnectionTimeout *time.Duration `json:"connectionTimeout,omitempty" yaml:"connectionTimeout,omitempty"`
@@ -92,7 +93,7 @@ func (ss *SSH) connect(host string) (*ssh.Client, error) {
 
 func (ss *SSH) addrReformat(host string) string {
 	if !strings.Contains(host, ":") {
-		host = fmt.Sprintf("%s:22", host)
+		host = fmt.Sprintf("%s:%d", host, ss.Port)
 	}
 	return host
 }


### PR DESCRIPTION
Signed-off-by: Liucw <liu.chuwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeclipper-labs/kubeclipper/issues/191

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 