### PR TITLE
feat: add provider precheck api and permissions

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -752,6 +752,39 @@
         }
       }
     },
+    "/api/core.kubeclipper.io/v1/cloudproviders/precheck": {
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Core-Cluster"
+        ],
+        "summary": "Check cloudProvider params is ok",
+        "operationId": "PreCheckCloudProvider",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1.CloudProvider"
+            }
+          },
+          {
+            "type": "boolean",
+            "description": "dry run Check cloudProvider params",
+            "name": "dryRun",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/core.kubeclipper.io/v1/cloudproviders/{name}": {
       "get": {
         "produces": [
@@ -6937,6 +6970,9 @@
         "id"
       ],
       "properties": {
+        "containerRuntime": {
+          "$ref": "#/definitions/v1.ContainerRuntime"
+        },
         "id": {
           "type": "string"
         },

--- a/pkg/apis/core/v1/registry.go
+++ b/pkg/apis/core/v1/registry.go
@@ -1006,6 +1006,15 @@ func SetupWebService(h *handler) *restful.WebService {
 			Required(false)).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}))
 
+	webservice.Route(webservice.POST("/cloudproviders/precheck").
+		To(h.PreCheckCloudProvider).
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		Doc("Check cloudProvider params is ok").
+		Reads(corev1.CloudProvider{}).
+		Param(webservice.QueryParameter(query.ParamDryRun, "dry run Check cloudProvider params").
+			Required(false).DataType("boolean")).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), nil))
+
 	webservice.Route(webservice.POST("/cloudproviders").
 		To(h.CreateCloudProvider).
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).

--- a/pkg/clustermanage/interface.go
+++ b/pkg/clustermanage/interface.go
@@ -1,8 +1,19 @@
 package clustermanage
 
-import "context"
+import (
+	"context"
+
+	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+)
 
 type CloudProvider interface {
 	Sync(ctx context.Context) error
 	Cleanup(tx context.Context) error
+	Expansion
+}
+
+type Expansion interface {
+	PreCheck(ctx context.Context) (bool, error)
+	GetKubeConfig(ctx context.Context, clusterName string) (string, error)
+	GetCertification(ctx context.Context, clusterName string) ([]v1.Certification, error)
 }

--- a/pkg/clustermanage/mock/mock.go
+++ b/pkg/clustermanage/mock/mock.go
@@ -3,26 +3,42 @@ package mock
 import (
 	"context"
 
-	log "github.com/sirupsen/logrus"
+	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 
 	"github.com/kubeclipper/kubeclipper/pkg/clustermanage"
 	"github.com/kubeclipper/kubeclipper/pkg/logger"
 )
 
 type Provider struct {
-	log logger.Logging
+	Provider *v1.CloudProvider
 }
 
-func NewProvider() clustermanage.CloudProvider {
-	return Provider{}
+func NewProvider(provider *v1.CloudProvider) clustermanage.CloudProvider {
+	return Provider{
+		Provider: provider,
+	}
 }
 
-func (Provider) Sync(ctx context.Context) error {
-	log.Info("mock provider sync")
+func (p Provider) Sync(ctx context.Context) error {
+	logger.Info("mock provider sync")
 	return nil
 }
 
-func (Provider) Cleanup(ctx context.Context) error {
-	log.Info("mock provider cleanup")
+func (p Provider) Cleanup(ctx context.Context) error {
+	logger.Info("mock provider cleanup")
 	return nil
+}
+
+func (p Provider) PreCheck(ctx context.Context) (bool, error) {
+	logger.Info("mock provider preCheck")
+	return true, nil
+}
+func (p Provider) GetKubeConfig(ctx context.Context, clusterName string) (string, error) {
+	logger.Info("mock provider getKubeConfig")
+	return "", nil
+}
+
+func (p Provider) GetCertification(ctx context.Context, clusterName string) ([]v1.Certification, error) {
+	logger.Info("mock provider getCertification")
+	return nil, nil
 }

--- a/pkg/controller/cloudpprovidercontroller/mock.go
+++ b/pkg/controller/cloudpprovidercontroller/mock.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	mockProvider := mock.NewProvider()
+	mockProvider := mock.NewProvider(provider)
 
 	if provider.ObjectMeta.DeletionTimestamp.IsZero() {
 		// insert finalizers

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -353,6 +353,57 @@ var Roles = []iamv1.GlobalRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/module":              "Cluster Management",
+				"kubeclipper.io/role-template-rules": "{\"cloudproviders\": \"view\"}",
+				"kubeclipper.io/alias-name":          "CloudProvider View",
+				"kubeclipper.io/internal":            "true",
+			},
+			Labels: map[string]string{
+				"kubeclipper.io/role-template": "true",
+			},
+			Name: "role-template-view-cloudproviders",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"core.kubeclipper.io"},
+				Resources: []string{"cloudproviders", "cloudproviders/precheck"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	},
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       iamv1.KindGlobalRole,
+			APIVersion: iamv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubeclipper.io/dependencies":        "[\"role-template-view-cloudproviders\"]",
+				"kubeclipper.io/module":              "Cluster Management",
+				"kubeclipper.io/role-template-rules": "{\"cloudproviders\": \"edit\"}",
+				"kubeclipper.io/alias-name":          "CloudProvider Edit",
+				"kubeclipper.io/internal":            "true",
+			},
+			Labels: map[string]string{
+				"kubeclipper.io/role-template": "true",
+			},
+			Name: "role-template-edit-cloudproviders",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"core.kubeclipper.io"},
+				Resources: []string{"cloudproviders", "cloudproviders/precheck"},
+				Verbs:     []string{"*"},
+			},
+		},
+	},
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       iamv1.KindGlobalRole,
+			APIVersion: iamv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubeclipper.io/module":              "Cluster Management",
 				"kubeclipper.io/role-template-rules": "{\"clusters\": \"view\"}",
 				"kubeclipper.io/alias-name":          "Cluster View",
 				"kubeclipper.io/internal":            "true",


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
add provider precheck api and permissions
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```