### PR TITLE
fix kubelet data dir do not take effect

### DIFF
--- a/pkg/scheme/core/v1/k8s/kubeadm_step.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_step.go
@@ -419,45 +419,27 @@ func (stepper *KubeadmConfig) JoinSteps(isControlPlane bool, nodes []v1.StepNode
 	if err != nil {
 		return nil, err
 	}
-	if isControlPlane {
-		return []v1.Step{
+	step := v1.Step{
+		ID:         strutil.GetUUID(),
+		Name:       "renderMasterJoinConfig",
+		Timeout:    metav1.Duration{Duration: 1 * time.Minute},
+		ErrIgnore:  false,
+		RetryTimes: 1,
+		Nodes:      nodes,
+		Action:     v1.ActionInstall,
+		Commands: []v1.Command{
 			{
-				ID:         strutil.GetUUID(),
-				Name:       "renderMasterJoinConfig",
-				Timeout:    metav1.Duration{Duration: 1 * time.Minute},
-				ErrIgnore:  false,
-				RetryTimes: 1,
-				Nodes:      nodes,
-				Action:     v1.ActionInstall,
-				Commands: []v1.Command{
-					{
 
-						Type:          v1.CommandCustom,
-						Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, kubeadmConfig, version, component.TypeStep),
-						CustomCommand: kubeadmBytes,
-					},
-				},
-			},
-		}, nil
-	}
-	return []v1.Step{
-		{
-			ID:         strutil.GetUUID(),
-			Name:       "renderWorkerJoinConfig",
-			Timeout:    metav1.Duration{Duration: 1 * time.Minute},
-			ErrIgnore:  false,
-			RetryTimes: 1,
-			Nodes:      nodes,
-			Action:     v1.ActionInstall,
-			Commands: []v1.Command{
-				{
-					Type:          v1.CommandCustom,
-					Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, kubeadmConfig, version, component.TypeStep),
-					CustomCommand: kubeadmBytes,
-				},
+				Type:          v1.CommandCustom,
+				Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, kubeadmConfig, version, component.TypeStep),
+				CustomCommand: kubeadmBytes,
 			},
 		},
-	}, nil
+	}
+	if isControlPlane {
+		step.Name = "renderWorkerJoinConfig"
+	}
+	return []v1.Step{step}, nil
 
 }
 

--- a/pkg/scheme/core/v1/k8s/kubeadm_step.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_step.go
@@ -164,6 +164,23 @@ func (runnable *Runnable) makeInstallSteps(metadata *component.ExtraMetadata) ([
 	installSteps = append(installSteps, steps...)
 
 	if len(runnable.Masters) > 1 {
+		kubeadmConf := KubeadmConfig{}
+		steps, err = kubeadmConf.InitStepper(&c, metadata).JoinSteps(true, utils.UnwrapNodeList(metadata.Masters)[1:])
+		if err != nil {
+			return nil, err
+		}
+		installSteps = append(installSteps, steps...)
+	}
+	if len(runnable.Workers) > 0 {
+		kubeadmConf := KubeadmConfig{}
+		steps, err = kubeadmConf.InitStepper(&c, metadata).JoinSteps(false, utils.UnwrapNodeList(metadata.Workers))
+		if err != nil {
+			return nil, err
+		}
+		installSteps = append(installSteps, steps...)
+	}
+
+	if len(runnable.Masters) > 1 {
 		cluNode := ClusterNode{}
 		steps, err = cluNode.InitStepper(&c, metadata).InstallSteps(NodeRoleMaster, utils.UnwrapNodeList(metadata.Masters)[1:])
 		if err != nil {
@@ -394,6 +411,54 @@ func (stepper *KubeadmConfig) InstallSteps(nodes []v1.StepNode) ([]v1.Step, erro
 			},
 		},
 	}, nil
+}
+
+func (stepper *KubeadmConfig) JoinSteps(isControlPlane bool, nodes []v1.StepNode) ([]v1.Step, error) {
+	stepper.IsControlPlane = isControlPlane
+	kubeadmBytes, err := json.Marshal(stepper)
+	if err != nil {
+		return nil, err
+	}
+	if isControlPlane {
+		return []v1.Step{
+			{
+				ID:         strutil.GetUUID(),
+				Name:       "renderMasterJoinConfig",
+				Timeout:    metav1.Duration{Duration: 1 * time.Minute},
+				ErrIgnore:  false,
+				RetryTimes: 1,
+				Nodes:      nodes,
+				Action:     v1.ActionInstall,
+				Commands: []v1.Command{
+					{
+
+						Type:          v1.CommandCustom,
+						Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, kubeadmConfig, version, component.TypeStep),
+						CustomCommand: kubeadmBytes,
+					},
+				},
+			},
+		}, nil
+	}
+	return []v1.Step{
+		{
+			ID:         strutil.GetUUID(),
+			Name:       "renderWorkerJoinConfig",
+			Timeout:    metav1.Duration{Duration: 1 * time.Minute},
+			ErrIgnore:  false,
+			RetryTimes: 1,
+			Nodes:      nodes,
+			Action:     v1.ActionInstall,
+			Commands: []v1.Command{
+				{
+					Type:          v1.CommandCustom,
+					Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, kubeadmConfig, version, component.TypeStep),
+					CustomCommand: kubeadmBytes,
+				},
+			},
+		},
+	}, nil
+
 }
 
 func (stepper *KubeadmConfig) UninstallSteps(nodes []v1.StepNode) ([]v1.Step, error) {

--- a/pkg/scheme/core/v1/k8s/node.go
+++ b/pkg/scheme/core/v1/k8s/node.go
@@ -130,6 +130,14 @@ func (stepper *GenNode) MakeSteps(metadata *component.ExtraMetadata, patchNodes 
 		}
 		stepper.installSteps = append(stepper.installSteps, steps...)
 
+		// Notice: only support join worker node now.
+		kubeadmConf := KubeadmConfig{}
+		steps, err = kubeadmConf.InitStepper(stepper.Cluster, metadata).JoinSteps(false, patchNodes)
+		if err != nil {
+			return err
+		}
+		stepper.installSteps = append(stepper.installSteps, steps...)
+
 		join := ClusterNode{}
 		steps, err = join.InitStepper(stepper.Cluster, metadata).InstallSteps(role, patchNodes)
 		if err != nil {

--- a/pkg/scheme/core/v1/k8s/template.go
+++ b/pkg/scheme/core/v1/k8s/template.go
@@ -88,7 +88,7 @@ streamingConnectionIdleTimeout: 0s
 syncFrequency: 3s
 volumeStatsAggPeriod: 1m
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/{{.ClusterConfigAPIVersion}}
 kind: InitConfiguration
 nodeRegistration:
 {{- if eq .ContainerRuntime  "containerd"}}
@@ -97,6 +97,25 @@ nodeRegistration:
   kubeletExtraArgs:
     root-dir: {{.Kubelet.RootDir}}
 `
+
+const KubeadmJoinTemplate = `apiVersion: kubeadm.k8s.io/{{.ClusterConfigAPIVersion}}
+kind: JoinConfiguration
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: {{.ControlPlaneEndpoint}}
+    token: {{.BootstrapToken}}
+    caCertHashes:
+      - {{.CACertHashes}}
+  timeout: 5m0s
+{{- if .IsControlPlane}}
+controlPlane: 
+  certificateKey: {{.CertificateKey}}{{end}}
+nodeRegistration:
+{{- if eq .ContainerRuntime  "containerd"}}
+  criSocket: /run/containerd/containerd.sock
+{{end}}
+  kubeletExtraArgs:
+    root-dir: {{.Kubelet.RootDir}}`
 
 const lvscareV111 = `
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```